### PR TITLE
feat/4472-modify-export-api-to-return-empty-array

### DIFF
--- a/src/components/HeaderInfo/ImportHistoricalDataModal.js
+++ b/src/components/HeaderInfo/ImportHistoricalDataModal.js
@@ -7,21 +7,6 @@ import {
 } from "../../utils/api/emissionsApi";
 import { useSelector } from "react-redux";
 
-// This is a very temporary bandaid fix for a problem in the API where the export sends back null for some of the 
-// child data lists and when you try to import that, it throws an error because 
-const deepRemoveVal = (obj, val = null) => {
-  for (const k in obj) {
-    if (obj[k] === val) {
-      delete obj[k];
-    }
-    if (Array.isArray(obj[k])) {
-      for (const i of obj[k]) deepRemoveVal(i);
-    }
-  }
-
-  return obj;
-};
-
 export const ImportHistoricalDataModal = ({
   closeModalHandler,
   setIsLoading,
@@ -47,7 +32,6 @@ export const ImportHistoricalDataModal = ({
 
     exportEmissionsData(selectedConfig.id, selectedYear, selectedQuarter, false)
       .then(({ data: exportResponse }) => {
-        deepRemoveVal(exportResponse);
         return importEmissionsData(exportResponse);
       })
       .then(({ data: importResponse, status }) => {


### PR DESCRIPTION
This PR removes the recursive function deepRemoveVal, which was written to replace null values with [] from the export api. The api has been updated to not return nulls for children collections data so this function (which slows down the import process) is no longer needed.
