### PR TITLE
added add, edit, and remove functionality for heat input gas

### DIFF
--- a/src/additional-functions/qa-dataTable-props.js
+++ b/src/additional-functions/qa-dataTable-props.js
@@ -448,6 +448,7 @@ export const qaAppendixECorrelationSummaryHeatInputGasProps = (selectedRow) => {
       gasGCV: 0,
       gasVolume: 0,
       gasHeatInput: 0,
+      monitoringSystemID: "string",
     },
     dropdownArray: [],
     columnNames: [

--- a/src/components/qaDatatablesContainer/QAExpandableRowsRender/QAExpandableRowsRender.test.js
+++ b/src/components/qaDatatablesContainer/QAExpandableRowsRender/QAExpandableRowsRender.test.js
@@ -21,7 +21,8 @@ import {
   qaFlowToLoadCheckProps,
   qaFuelFlowToLoadBaselineProps,
   qaAppendixECorrelationSummaryHeatInputOilProps,
-  qaProtocalGasProps
+  qaProtocalGasProps,
+  qaAppendixECorrelationSummaryHeatInputGasProps
 } from "../../../additional-functions/qa-dataTable-props";
 
 const mock = new MockAdapter(axios);
@@ -873,6 +874,82 @@ describe('Test cases for QAExpandableRowsRender', () => {
     // remove row
     const deleteBtns = await screen.getAllByRole('button', { name: /Remove/i })
     expect(deleteBtns).toHaveLength(appendixECorrTestRunData.length)
+    const secondDeleteBtn = deleteBtns[1]
+    userEvent.click(secondDeleteBtn)
+    const confirmBtns = screen.getAllByRole('button', { name: /Yes/i })
+    userEvent.click(confirmBtns[1])
+  })
+
+  test('renders Appendix E Correlation Heat Input Gas data rows and create/save/delete', async () => {
+    const appendixECorrelationSummaryHeatInputGasData = [
+      {
+        "id": "id1",
+        "appECorrTestRunId": "appECorrTestRunId",
+        "monitoringSystemId": "monitoringSystemId",
+        "gasVolume": 1,
+        "gasGCV": 1,
+        "gasHeatInput": 1,
+        "calculatedGasHeatInput": 1,
+        "userId": "string",
+        "addDate": "string",
+        "updateDate": "string"
+      },
+      {
+        "id": "id2",
+        "appECorrTestRunId": "appECorrTestRunId",
+        "monitoringSystemId": "monitoringSystemId",
+        "gasVolume": 1,
+        "gasGCV": 1,
+        "gasHeatInput": 1,
+        "calculatedGasHeatInput": 1,
+        "userId": "string",
+        "addDate": "string",
+        "updateDate": "string"
+      },
+    ]
+
+    const getUrl = `${qaCertBaseUrl}/locations/${locId}/test-summary/${testSumId}/appendix-e-correlation-test-summaries/${appECorrTestSumId}/appendix-e-correlation-test-runs/${appECorrTestRunId}/appendix-e-heat-input-from-gases`;
+    const postUrl = `${qaCertBaseUrl}/workspace/locations/${locId}/test-summary/${testSumId}/appendix-e-correlation-test-summaries/${appECorrTestSumId}/appendix-e-correlation-test-runs/${appECorrTestRunId}/appendix-e-heat-input-from-gases`;
+    const putUrl = new RegExp(`${qaCertBaseUrl}/workspace/locations/${locId}/test-summary/${testSumId}/appendix-e-correlation-test-summaries/${appECorrTestSumId}/appendix-e-correlation-test-runs/${appECorrTestRunId}/appendix-e-heat-input-from-gases/${idRegex}`);
+    const deleteUrl = new RegExp(`${qaCertBaseUrl}/workspace/locations/${locId}/test-summary/${testSumId}/appendix-e-correlation-test-summaries/${appECorrTestSumId}/appendix-e-correlation-test-runs/${appECorrTestRunId}/appendix-e-heat-input-from-gases/${idRegex}`);
+  
+    mock.onGet(getUrl).reply(200, appendixECorrelationSummaryHeatInputGasData)
+    mock.onPost(postUrl).reply(200, 'created')
+    mock.onPut(putUrl).reply(200, 'updated')
+    mock.onDelete(deleteUrl).reply(200, 'deleted')
+
+    mock.onGet(`https://api.epa.gov/easey/dev/qa-certification-mgmt/locations/${locId}/test-summary/${testSumId}`)
+    .reply(200,[{"id":"L3FY866-950F544520244336B5ED7E3824642F9E","locationId":"2286","stackPipeId":null,"unitId":"1","testTypeCode":"APPE","monitoringSystemID":"400","componentID":null,"spanScaleCode":null,"testNumber":"01NOX2021-2","testReasonCode":"QA","testDescription":null,"testResultCode":null,"calculatedTestResultCode":null,"beginDate":"2021-02-05","beginHour":8,"beginMinute":0,"endDate":"2021-02-05","endHour":15,"endMinute":26,"gracePeriodIndicator":null,"calculatedGracePeriodIndicator":null,"year":null,"quarter":null,"testComment":null,"injectionProtocolCode":null,"calculatedSpanValue":null,"evalStatusCode":"EVAL","userId":"rboehme-dp","addDate":"4/7/2021, 7:34:01 AM","updateDate":"11/9/2022, 3:05:01 PM","reportPeriodId":null}]);
+    
+
+    const props = qaAppendixECorrelationSummaryHeatInputGasProps()
+    const idArray = [locId, testSumId, appECorrTestSumId, appECorrTestRunId, id]
+    const data = { locationId: locId, id: appECorrTestRunId }
+    renderComponent(props, idArray, data);
+
+    // renders rows
+    const rows = await screen.findAllByRole('row')
+    expect(mock.history.get.length).not.toBe(0)
+    expect(rows).not.toHaveLength(0)
+
+    // add row
+    /*const addBtn = screen.getAllByRole('button', { name: /Add/i })
+    userEvent.click(addBtn[0])
+    let saveAndCloseBtn = screen.getByRole('button', { name: /Click to save/i })
+    userEvent.click(saveAndCloseBtn)
+    setTimeout(() => expect(mock.history.post.length).toBe(1), 1000)
+*/
+    // edit row
+    const editBtns = screen.getAllByRole('button', { name: /Edit/i })
+    expect(editBtns).toHaveLength(appendixECorrelationSummaryHeatInputGasData.length)
+    userEvent.click(editBtns[0])
+    let saveAndCloseBtn = screen.getByRole('button', { name: /Click to save/i })
+    userEvent.click(saveAndCloseBtn)
+    setTimeout(() => expect(mock.history.put.length).toBe(1), 1000)
+
+    // remove row
+    const deleteBtns = await screen.getAllByRole('button', { name: /Remove/i })
+    expect(deleteBtns).toHaveLength(appendixECorrelationSummaryHeatInputGasData.length)
     const secondDeleteBtn = deleteBtns[1]
     userEvent.click(secondDeleteBtn)
     const confirmBtns = screen.getAllByRole('button', { name: /Yes/i })

--- a/src/utils/api/qaCertificationsAPI.js
+++ b/src/utils/api/qaCertificationsAPI.js
@@ -75,7 +75,7 @@ export const getQATestSummaryByID = async (locID, id) => {
 
   // *** workspace section url (authenticated)
   if (window.location.href.indexOf("workspace") > -1) {
-    url = `${url}/workspace`;
+    url = `${url}workspace`;
   }
 
   // *** attach the rest of the url
@@ -1112,9 +1112,9 @@ export const getAppendixEHeatInputGasData = async (
   locId,
   testSumId,
   appECorrTestSumId,
-  appECorrTestrunId
+  appECorrTestRunId
 ) => {
-  const path = `/locations/${locId}/test-summary/${testSumId}/appendix-e-correlation-test-summaries/${appECorrTestSumId}/appendix-e-correlation-test-runs/${appECorrTestrunId}/appendix-e-heat-input-from-gases`;
+  const path = `/locations/${locId}/test-summary/${testSumId}/appendix-e-correlation-test-summaries/${appECorrTestSumId}/appendix-e-correlation-test-runs/${appECorrTestRunId}/appendix-e-heat-input-from-gases`;
   const url = getApiUrl(path);
   return axios.get(url).then(handleResponse).catch(handleError);
 };
@@ -1123,10 +1123,68 @@ export const createAppendixEHeatInputGas = async (
   locId,
   testSumId,
   appECorrTestSumId,
-  appECorrTestrunId,
+  appECorrTestRunId,
   payload
 ) => {
-  const path = `/locations/${locId}/test-summary/${testSumId}/appendix-e-correlation-test-summaries/${appECorrTestSumId}/appendix-e-correlation-test-runs${appECorrTestrunId}/appendix-e-heat-input-from-gases`;
+  const testSummary = await getQATestSummaryByID(locId, testSumId);
+  payload.monitoringSystemID = testSummary.data.monitoringSystemID;
+  const path = `/locations/${locId}/test-summary/${testSumId}/appendix-e-correlation-test-summaries/${appECorrTestSumId}/appendix-e-correlation-test-runs/${appECorrTestRunId}/appendix-e-heat-input-from-gases`;
+  const url = getApiUrl(path);
+  try {
+    return handleResponse(
+      await secureAxios({
+        method: "POST",
+        url: url,
+        data: payload,
+      })
+    );
+  } catch (error) {
+    return handleError(error);
+  }
+};
+
+export const updateAppendixECorrelationHeatInputGas = async (
+  locId,
+  testSumId,
+  appECorrTestSumId,
+  appECorrTestRunId, 
+  id,
+  payload
+) => {
+  const path = `/locations/${locId}/test-summary/${testSumId}/appendix-e-correlation-test-summaries/${appECorrTestSumId}/appendix-e-correlation-test-runs/${appECorrTestRunId}/appendix-e-heat-input-from-gases/${id}`;
+  const url = getApiUrl(path);
+  try {
+    return handleResponse(
+      await secureAxios({
+        method: "PUT",
+        url: url,
+        data: payload,
+      })
+    );
+  } catch (error) {
+    return handleImportError(error);
+  }
+}
+
+export const deleteAppendixECorrelationHeatInputGas = async (
+  locId,
+  testSumId,
+  appECorrTestSumId,
+  appECorrTestRunId, 
+  id,
+) => {
+  const path = `/locations/${locId}/test-summary/${testSumId}/appendix-e-correlation-test-summaries/${appECorrTestSumId}/appendix-e-correlation-test-runs/${appECorrTestRunId}/appendix-e-heat-input-from-gases/${id}`;
+  const url = getApiUrl(path);
+  try {
+    return handleResponse(
+      await secureAxios({
+        method: "DELETE",
+        url,
+      })
+    );
+  } catch (error) {
+    return handleError(error);
+  }
 };
 
 export const getAppendixEHeatInputOilData = async (

--- a/src/utils/api/qaCertificationsApi.test.js
+++ b/src/utils/api/qaCertificationsApi.test.js
@@ -18,7 +18,7 @@ const rataRunId = 'rataRunId'
 const flowRataRunId = 'flowRataRunId'
 const id = 'id'
 const appECorrTestSumId = 'appECorrTestSumId'
-const appECorrTestrunId = 'appECorrTestrunId'
+const appECorrTestRunId = 'appECorrTestRunId'
 
 
 describe("QA Cert API", function () {
@@ -151,7 +151,7 @@ describe("QA Cert API", function () {
 
     test('createAppendixECorrelationSummary', async () => {
       const payload = { appendixECorrelationSummary: 'data' }
-      const postAppendixECorrelationSummaryUrl = `${qaCertBaseUrl}/workspace/locations/${locId}/test-summary/${testSumId}/appendix-e-correlation-test-summaries`;
+      const postAppendixECorrelationSummaryUrl = `${qaCertBaseUrl}/locations/${locId}/test-summary/${testSumId}/appendix-e-correlation-test-summaries`;
       mock.onPost(postAppendixECorrelationSummaryUrl).reply(200, payload)
 
       const resp = await qaCert.createAppendixECorrelationSummaryRecord(locId, testSumId, payload)
@@ -162,7 +162,7 @@ describe("QA Cert API", function () {
 
     test('updateAppendixECorrelationSummary', async () => {
       const payload = { appendixECorrelationSummary: 'data' }
-      const postAppendixECorrelationSummaryUrl = `${qaCertBaseUrl}/workspace/locations/${locId}/test-summary/${testSumId}/appendix-e-correlation-test-summaries`;
+      const postAppendixECorrelationSummaryUrl = `${qaCertBaseUrl}/locations/${locId}/test-summary/${testSumId}/appendix-e-correlation-test-summaries`;
       mock.onPost(postAppendixECorrelationSummaryUrl).reply(200, payload)
 
       const resp = await qaCert.updateAppendixECorrelationSummaryRecord(locId, testSumId, id, payload)
@@ -174,7 +174,7 @@ describe("QA Cert API", function () {
 
   describe('RATA Test Qualification CRUD operations', () => {
     test('deleteTestQualification', async () => {
-      const deleteTestQualUrl = `${qaCertBaseUrl}/workspace/locations/${locId}/test-summary/${testSumId}/test-qualifications/${id}`
+      const deleteTestQualUrl = `${qaCertBaseUrl}/locations/${locId}/test-summary/${testSumId}/test-qualifications/${id}`
       mock.onDelete(deleteTestQualUrl).reply(200, 'deleted')
 
       const resp = await qaCert.deleteRataSummary(locId, testSumId, id)
@@ -189,10 +189,10 @@ describe("QA Cert API", function () {
 
     test('getAppendixEHeatInputOilData', async () => {
       const appendixECorrelationHeatInputOil = [{ appendixECorrelationHeatInputOil: 'data' }]
-      const postAppendixEHeatInputOilUrl = `${qaCertBaseUrl}/locations/${locId}/test-summary/${testSumId}/appendix-e-correlation-test-summaries/${appECorrTestSumId}/appendix-e-correlation-test-runs/${appECorrTestrunId}/appendix-e-heat-input-from-oils`;
+      const postAppendixEHeatInputOilUrl = `${qaCertBaseUrl}/locations/${locId}/test-summary/${testSumId}/appendix-e-correlation-test-summaries/${appECorrTestSumId}/appendix-e-correlation-test-runs/${appECorrTestRunId}/appendix-e-heat-input-from-oils`;
       mock.onGet(postAppendixEHeatInputOilUrl).reply(200, appendixECorrelationHeatInputOil)
   
-      const resp = await qaCert.getAppendixEHeatInputOilData(locId, testSumId, appECorrTestSumId,appECorrTestrunId)
+      const resp = await qaCert.getAppendixEHeatInputOilData(locId, testSumId, appECorrTestSumId,appECorrTestRunId)
   
       expect(mock.history.get.length).toBe(1)
       expect(resp.data).toStrictEqual(appendixECorrelationHeatInputOil)
@@ -200,10 +200,10 @@ describe("QA Cert API", function () {
   
     test('createAppendixEHeatInputOil', async () => {
       const payload = { appendixECorrelationHeatInputOil: 'data' }
-      const postAppendixEHeatInputOilUrl = `${qaCertBaseUrl}/workspace/locations/${locId}/test-summary/${testSumId}/appendix-e-correlation-test-summaries/${appECorrTestSumId}/appendix-e-correlation-test-runs/${appECorrTestrunId}/appendix-e-heat-input-from-oils`;
+      const postAppendixEHeatInputOilUrl = `${qaCertBaseUrl}/locations/${locId}/test-summary/${testSumId}/appendix-e-correlation-test-summaries/${appECorrTestSumId}/appendix-e-correlation-test-runs/${appECorrTestRunId}/appendix-e-heat-input-from-oils`;
       mock.onPost(postAppendixEHeatInputOilUrl).reply(200, payload)
   
-      const resp = await qaCert.createAppendixEHeatInputOil(locId, testSumId,appECorrTestSumId,appECorrTestrunId, payload)
+      const resp = await qaCert.createAppendixEHeatInputOil(locId, testSumId,appECorrTestSumId,appECorrTestRunId, payload)
   
       expect(mock.history.post.length).toBe(1)
       expect(resp.data).toStrictEqual(payload)
@@ -211,17 +211,17 @@ describe("QA Cert API", function () {
   
     test('updateAppendixECorrelationHeatInputOil', async () => {
       const payload = { appendixECorrelationHeatInputOil: 'data' }
-      const putAppendixEHeatInputOilUrl = `${qaCertBaseUrl}/workspace/locations/${locId}/test-summary/${testSumId}/appendix-e-correlation-test-summaries/${appECorrTestSumId}/appendix-e-correlation-test-runs/${appECorrTestrunId}/appendix-e-heat-input-from-oils/${id}`;
+      const putAppendixEHeatInputOilUrl = `${qaCertBaseUrl}/locations/${locId}/test-summary/${testSumId}/appendix-e-correlation-test-summaries/${appECorrTestSumId}/appendix-e-correlation-test-runs/${appECorrTestRunId}/appendix-e-heat-input-from-oils/${id}`;
       mock.onPost(putAppendixEHeatInputOilUrl).reply(200, payload)
   
-      const resp = await qaCert.updateAppendixECorrelationHeatInputOil(locId, testSumId,appECorrTestSumId,appECorrTestrunId, id, payload)
+      const resp = await qaCert.updateAppendixECorrelationHeatInputOil(locId, testSumId,appECorrTestSumId,appECorrTestRunId, id, payload)
   
       expect(mock.history.put.length).toBe(1)
       expect(resp.data).toStrictEqual(payload)
     })
   
     test('deleteAppendixECorrelationHeatInputOil', async () => {
-      const deleteAppendixEHeatInputOilUrl = `${qaCertBaseUrl}/workspace/locations/${locId}/test-summary/${testSumId}/appendix-e-correlation-test-summaries/${appECorrTestSumId}/appendix-e-correlation-test-runs/${appECorrTestrunId}/appendix-e-heat-input-from-oils/${id}`;
+      const deleteAppendixEHeatInputOilUrl = `${qaCertBaseUrl}/locations/${locId}/test-summary/${testSumId}/appendix-e-correlation-test-summaries/${appECorrTestSumId}/appendix-e-correlation-test-runs/${appECorrTestRunId}/appendix-e-heat-input-from-oils/${id}`;
       mock.onDelete(deleteAppendixEHeatInputOilUrl).reply(200, 'deleted')
   
       const resp = await qaCert.deleteAppendixECorrelationHeatInputOil(locId, testSumId, id)
@@ -230,29 +230,54 @@ describe("QA Cert API", function () {
       expect(resp.data).toStrictEqual('deleted')
     })
   })
+
+  describe('Appendix E Correlation Heat Input from Gas CRUD operations', () => {
+
+    test('getAppendixEHeatInputGasData', async () => {
+      const appendixEHeatInputGasData = [{ appendixECorrelationHeatInputGas: 'data' }, { appendixECorrelationHeatInputGas: 'data2' }]
+      const getAppendixEHeatInputGasDataUrl = `${qaCertBaseUrl}/locations/${locId}/test-summary/${testSumId}/appendix-e-correlation-test-summaries/${appECorrTestSumId}/appendix-e-correlation-test-runs/${appECorrTestRunId}/appendix-e-heat-input-from-gases`;
+      mock.onGet(getAppendixEHeatInputGasDataUrl).reply(200, appendixEHeatInputGasData)
+
+      const resp = await qaCert.getAppendixEHeatInputGasData(locId, testSumId, appECorrTestSumId, appECorrTestRunId)
+
+      expect(mock.history.get.length).toBe(1)
+      expect(resp.data).toStrictEqual(appendixEHeatInputGasData)
+    })
+
+    test('createAppendixEHeatInputGas', async () => {
+      const payload = { appendixECorrelationHeatInputGas: 'data' }
+      const postAppendixEHeatInputGasDataUrl = `${qaCertBaseUrl}/locations/${locId}/test-summary/${testSumId}/appendix-e-correlation-test-summaries/${appECorrTestSumId}/appendix-e-correlation-test-runs/${appECorrTestRunId}/appendix-e-heat-input-from-gases`;
+      mock.onPost(postAppendixEHeatInputGasDataUrl).reply(200, payload)
+      mock.onGet(`https://api.epa.gov/easey/dev/qa-certification-mgmt/locations/${locId}/test-summary/${testSumId}`)
+      .reply(200,[{"id":"L3FY866-950F544520244336B5ED7E3824642F9E","locationId":"2286","stackPipeId":null,"unitId":"1","testTypeCode":"APPE","monitoringSystemID":"400","componentID":null,"spanScaleCode":null,"testNumber":"01NOX2021-2","testReasonCode":"QA","testDescription":null,"testResultCode":null,"calculatedTestResultCode":null,"beginDate":"2021-02-05","beginHour":8,"beginMinute":0,"endDate":"2021-02-05","endHour":15,"endMinute":26,"gracePeriodIndicator":null,"calculatedGracePeriodIndicator":null,"year":null,"quarter":null,"testComment":null,"injectionProtocolCode":null,"calculatedSpanValue":null,"evalStatusCode":"EVAL","userId":"rboehme-dp","addDate":"4/7/2021, 7:34:01 AM","updateDate":"11/9/2022, 3:05:01 PM","reportPeriodId":null}]);
+
+      const resp = await qaCert.createAppendixEHeatInputGas(locId, testSumId, appECorrTestSumId, appECorrTestRunId, payload)
+
+      expect(mock.history.post.length).toBe(1)
+      expect(resp.data).toStrictEqual(payload)
+    })
+
+    test('updateAppendixECorrelationHeatInputGas', async () => {
+      const payload = { appendixECorrelationHeatInputGas: 'data' }
+      const putAppendixEHeatInputGasDataUrl = `${qaCertBaseUrl}/locations/${locId}/test-summary/${testSumId}/appendix-e-correlation-test-summaries/${appECorrTestSumId}/appendix-e-correlation-test-runs/${appECorrTestRunId}/appendix-e-heat-input-from-gases/${id}`
+      mock.onPut(putAppendixEHeatInputGasDataUrl).reply(200, payload)
+
+      const resp = await qaCert.updateAppendixECorrelationHeatInputGas(locId, testSumId, appECorrTestSumId, appECorrTestRunId, id, payload)
+
+      expect(mock.history.put.length).toBe(1)
+      expect(resp.data).toStrictEqual(payload)
+    })
+
+    test('deleteAppendixECorrelationHeatInputGas', async () => {
+      const deleteAppendixEHeatInputGasDataUrl = `${qaCertBaseUrl}/locations/${locId}/test-summary/${testSumId}/appendix-e-correlation-test-summaries/${appECorrTestSumId}/appendix-e-correlation-test-runs/${appECorrTestRunId}/appendix-e-heat-input-from-gases/${id}`
+      mock.onDelete(deleteAppendixEHeatInputGasDataUrl).reply(200, 'deleted')
+
+      const resp = await qaCert.deleteAppendixECorrelationHeatInputGas(locId, testSumId, appECorrTestSumId, appECorrTestRunId, id)
+
+      expect(mock.history.delete.length).toBe(1)
+      expect(resp.data).toStrictEqual('deleted')
+    })
+  })
 })
 
-describe('Appendix E Correlation Heat Input from Gas CRUD operations', () => {
 
-  test('getAppendixEHeatInputGasData', async () => {
-    const appendixECorrelationHeatInputGas = [{ appendixECorrelationHeatInputGas: 'data' }]
-    const postAppendixEHeatInputGasUrl = `${qaCertBaseUrl}/locations/${locId}/test-summary/${testSumId}/appendix-e-correlation-test-summaries/${appECorrTestSumId}/appendix-e-correlation-test-runs/${appECorrTestrunId}/appendix-e-heat-input-from-gases`;
-    mock.onGet(postAppendixEHeatInputGasUrl).reply(200, appendixECorrelationHeatInputGas)
-
-    const resp = await qaCert.getAppendixEHeatInputGasData(locId, testSumId, appECorrTestSumId,appECorrTestrunId)
-
-    expect(mock.history.get.length).toBe(1)
-    expect(resp.data).toStrictEqual(appendixECorrelationSummaryData)
-  })
-
-  test('createAppendixECorrelationSummaryRecord', async () => {
-    const payload = { appendixECorrelationHeatInputGas: 'data' }
-    const postAppendixEHeatInputGasUrl = `${qaCertBaseUrl}/workspace/locations/${locId}/test-summary/${testSumId}/appendix-e-correlation-test-summaries/${appECorrTestSumId}/appendix-e-correlation-test-runs/${appECorrTestrunId}/appendix-e-heat-input-from-gases`;
-    mock.onPost(postAppendixEHeatInputGasUrl).reply(200, payload)
-
-    const resp = await qaCert.createAppendixECorrelationSummaryRecord(locId, testSumId,appECorrTestSumId,appECorrTestrunId, payload)
-
-    expect(mock.history.post.length).toBe(1)
-    expect(resp.data).toStrictEqual(payload)
-  })
-})

--- a/src/utils/selectors/QACert/assert.js
+++ b/src/utils/selectors/QACert/assert.js
@@ -107,14 +107,12 @@ export const getDataTableApis = async (name, location, id, extraIdsArr) => {
         .getFuelFlowToLoadBaseline(location, id)
         .catch(error => console.log('error fetching fuel flow to load baseline data', error))
     case appendixECorrTestRun:
-      console.log("extraids for run", extraIdsArr);
       return qaApi
         .getAppendixERunData(extraIdsArr[0], extraIdsArr[1], id)
         .catch((error) =>
           console.log("error fetching appendix E test run data", error)
         );
     case appendixECorrHeatInputGas:
-      console.log("extraids for heat", extraIdsArr);
       return qaApi
         .getAppendixEHeatInputGasData(
           extraIdsArr[0],
@@ -311,7 +309,7 @@ export const removeDataSwitch = async (
         });
     case appendixECorrHeatInputGas:
       return qaApi
-        .deleteAppendixECorrelationSummaryRecord(locationId, id, row.id)
+        .deleteAppendixECorrelationHeatInputGas(extraIdsArr[0], extraIdsArr[1], extraIdsArr[2], id, row.id)
         .catch((error) => {
           console.log("error", error);
         });
@@ -472,6 +470,16 @@ export const saveDataSwitch = (userInput, name, location, id, extraIdsArr) => {
           extraIdsArr[0],
           extraIdsArr[1],
           id,
+          userInput.id,
+          userInput
+        ).catch((error) => {console.log("error", error)});
+    case appendixECorrHeatInputGas:
+      return qaApi
+        .updateAppendixECorrelationHeatInputGas(
+          extraIdsArr[0], 
+          extraIdsArr[1], 
+          extraIdsArr[2], 
+          id, 
           userInput.id,
           userInput
         ).catch((error) => {console.log("error", error)});


### PR DESCRIPTION
As an ECMPS user, I want to add new Appendix E Heat Input From Gas data in the Workspace so that I can look at real-time data or add test information as needed

As an ECMPS user (logged-in), I want to update Appendix E Heat Input From Gas data so that I can add information to a test

As an ECMPS user, I want the ability to remove Appendix E Heat Input From Gas data so that I can update data as needed