### PR TITLE
Hide the 'View Audit Report' Button' in MP Header

### DIFF
--- a/src/components/HeaderInfo/HeaderInfo.js
+++ b/src/components/HeaderInfo/HeaderInfo.js
@@ -1049,6 +1049,7 @@ export const HeaderInfo = ({
                 >
                   View Comments
                 </Button>
+                {/* Hide this button until click behavior is implemented
                 <Button
                   outline
                   type="button"
@@ -1058,6 +1059,7 @@ export const HeaderInfo = ({
                 >
                   View Audit Report
                 </Button>
+                */}
                 <Button
                   outline
                   type="button"


### PR DESCRIPTION
Comments out the 'View Audit Report' button from the MP Header until the onClick behavior is implemented