### PR TITLE
feature/4488 - Pre-populate Monitoring System IDs in Add/Edit Modal

### DIFF
--- a/src/components/QACertTestSummaryTabRender/QACertTestSummaryTabRender.js
+++ b/src/components/QACertTestSummaryTabRender/QACertTestSummaryTabRender.js
@@ -45,6 +45,7 @@ export const QACertTestSummaryRender = ({
           user={user}
           sectionSelect={sectionSelect}
           selectedLocation={{
+            id: locations[locationSelect[0]]["id"],
             name: locations[locationSelect[0]]["name"],
             stackPipeId: locations[locationSelect[0]]["stackPipeId"],
             unitId: locations[locationSelect[0]]["unitId"],

--- a/src/components/qaDatatablesContainer/QATestSummaryDataTable/QATestSummaryDataTable.js
+++ b/src/components/qaDatatablesContainer/QATestSummaryDataTable/QATestSummaryDataTable.js
@@ -90,6 +90,7 @@ const QATestSummaryDataTable = ({
       "testResultCode",
       selectedLocation.unitId ? "unitId" : "stackPipeId",
       "componentID",
+      "monitoringSystemID",
       "prefilteredTestSummaries",
     ],
   ]);
@@ -106,6 +107,7 @@ const QATestSummaryDataTable = ({
         "testResultCode",
         selectedLocation.unitId ? "unitId" : "stackPipeId",
         "componentID",
+        "monitoringSystemID",
         "prefilteredTestSummaries",
       ],
     ]);
@@ -160,6 +162,7 @@ const QATestSummaryDataTable = ({
     allPromises.push(dmApi.getAllTestResultCodes());
     allPromises.push(dmApi.getPrefilteredTestSummaries());
     allPromises.push(mpApi.getMonitoringComponents(locationSelectValue));
+    allPromises.push(mpApi.getMonitoringSystems(selectedLocation.id));
     Promise.all(allPromises).then((response) => {
       dropdownArray[0].forEach((val, i) => {
         if (i === 0) {
@@ -187,6 +190,10 @@ const QATestSummaryDataTable = ({
             getOptions(d, "componentId", "componentId")
           );
         } else if (i === 6) {
+          dropdowns[dropdownArray[0][i]] = response[6].data.map((d) =>
+              getOptions(d, "id", "monitoringSystemId")
+          );
+        } else if (i === 7) {
           let noDupesTestCodes = response[4].data.map((code) => {
             return code["testTypeCode"];
           });

--- a/src/components/qaDatatablesContainer/QATestSummaryDataTable/QATestSummaryDataTable.test.js
+++ b/src/components/qaDatatablesContainer/QATestSummaryDataTable/QATestSummaryDataTable.test.js
@@ -24,6 +24,7 @@ const testReasonCodesUrl = new RegExp(`${config.services.mdm.uri}/test-reason-co
 const testResultCodesUrl = new RegExp(`${config.services.mdm.uri}/test-result-codes`)
 const prefilterTestSummariesUrl = new RegExp(`${config.services.mdm.uri}/relationships/test-summaries`)
 const getMonitoringComponentsUrl = new RegExp(`${config.services.monitorPlans.uri}/locations/${locId}/components`)
+const getMonitoringSystemssUrl = new RegExp(`${config.services.monitorPlans.uri}/locations/${locId}/systems`)
 
 const testSummary = [
   {
@@ -71,6 +72,7 @@ mock.onGet(testReasonCodesUrl).reply(200, [])
 mock.onGet(testResultCodesUrl).reply(200, [])
 mock.onGet(prefilterTestSummariesUrl).reply(200, [])
 mock.onGet(getMonitoringComponentsUrl).reply(200, [])
+mock.onGet(getMonitoringSystemssUrl).reply(200, [])
 
 const initialState = {
   facilities: [],

--- a/src/utils/selectors/QACert/LinearitySummary.js
+++ b/src/utils/selectors/QACert/LinearitySummary.js
@@ -136,7 +136,7 @@ export const getQAColsByTestCode = (testCode) => {
 export const getQAModalDetailsByTestCode = (testCode, selectedLocation) => {
   // const unitId = ["Unit or Stack Pipe ID", "nonFilteredDropdown", "", ""]
   const testTypeCode = ["Test Type Code", "mainDropdown", "mainDropdown", ""]
-  const monitoringSystemID = ["Monitoring System ID", "input", "", ""]
+  const monitoringSystemID = ["Monitoring System ID", "nonFilteredDropdown", "", ""]
   const componentID = ["Component ID", "nonFilteredDropdown", "", ""]
   const spanScaleCode = ["Span Scale Code", "nonFilteredDropdown", "", ""]
   const testNumber = ["Test Number", "input", "", ""]


### PR DESCRIPTION
Prep-populates the Monitoring System ID dropdown select in the Add/Edit modal, using values applicable to the selected Location