### PR TITLE
Feature/3031 transmitter transducer accuracy

### DIFF
--- a/src/additional-functions/qa-dataTable-props.js
+++ b/src/additional-functions/qa-dataTable-props.js
@@ -719,6 +719,40 @@ export const qaFuelFlowmeterAccuracyDataProps = () => {
   }
 }
 
+export const qaTransmitterTransducerAccuracyDataProps = () => {
+  return {
+    dataTableName: "Transmitter Transducer Accuracy Data",
+    payload: {},
+    dropdownArray: ["lowLevelAccuracySpecCode", "midLevelAccuracySpecCode", "highLevelAccuracySpecCode"],
+    mdmProps: [
+      {
+        codeTable: "accuracy-spec-codes",
+        responseProps: {
+          code: "accuracySpecCode",
+          description: "accuracySpecDescription"
+        }
+      },
+    ],
+    columnNames: [
+      "Low Level Accuracy",
+      "Low Level Accuracy Spec Code",
+      "Mid Level Accuracy",
+      "Mid Level Accuracy Spec Code",
+      "High Level Accuracy",
+      "High Level Accuracy Spec Code",
+    ],
+    controlInputs: {
+      lowLevelAccuracy: ["Low Level Accuracy", "input", "", ""],
+      lowLevelAccuracySpecCode: ["Low Level Accuracy Spec Code", "dropdown", "", ""],
+      midLevelAccuracy: ["Mid Level Accuracy", "input", "", ""],
+      midLevelAccuracySpecCode: ["Mid Level Accuracy Spec Code", "dropdown", "", ""],
+      highLevelAccuracy: ["High Level Accuracy", "input", "", ""],
+      highLevelAccuracySpecCode: ["High Level Accuracy Spec Code", "dropdown", "", ""],
+    },
+    controlDatePickerInputs: {},
+  }
+}
+
 export const qaOnOffCalibrationProps = () => {
   return {
     dataTableName: "Online Offline Calibration",

--- a/src/components/qaDatatablesContainer/QAExpandableRowsRender/QAExpandableRowsRender.js
+++ b/src/components/qaDatatablesContainer/QAExpandableRowsRender/QAExpandableRowsRender.js
@@ -314,7 +314,6 @@ const QAExpandableRowsRender = ({
   const loadDropdownsData = (name) => {
     let dropdowns = {};
     const allPromises = [];
-
     switch (name) {
       case "Protocol Gas":
       case "Linearity Test":
@@ -507,6 +506,38 @@ const QAExpandableRowsRender = ({
                 return { code: d[codeLabel], name: d[descriptionLabel] };
               });
               dropdowns["oilDensityUnitsOfMeasureCode"] = curResp.data.map((d) => {
+                return { code: d[codeLabel], name: d[descriptionLabel] };
+              });
+            }
+          });
+          for (const options of Object.values(dropdowns)) {
+            options.unshift({ code: "", name: "-- Select a value --" });
+          }
+          setMdmData(dropdowns);
+        }).catch((error => console.log(error)))
+        break;
+      case "Transmitter Transducer Accuracy Data":
+        allPromises.push(dmApi.getAllAccuracySpecCodes());
+        Promise.all(allPromises).then((responses) => {
+          responses.forEach((curResp, i) => {
+            let codeLabel;
+            let descriptionLabel;
+            switch (i) {
+              case 0:
+                codeLabel = "accuracySpecCode";
+                descriptionLabel = "accuracySpecDescription";
+                break;
+              default:
+                break;
+            }
+            dropdowns[dropdownArray[i]] = curResp.data.map((d) => {
+              return { code: d[codeLabel], name: d[descriptionLabel] };
+            });
+            if (i === 0) {
+              dropdowns["midLevelAccuracySpecCode"] = curResp.data.map((d) => {
+                return { code: d[codeLabel], name: d[descriptionLabel] };
+              });
+              dropdowns["highLevelAccuracySpecCode"] = curResp.data.map((d) => {
                 return { code: d[codeLabel], name: d[descriptionLabel] };
               });
             }

--- a/src/components/qaDatatablesContainer/QATestSummaryDataTable/QATestSummaryDataTable.js
+++ b/src/components/qaDatatablesContainer/QATestSummaryDataTable/QATestSummaryDataTable.js
@@ -22,6 +22,7 @@ import {
   qaCalibrationInjectionProps,
   qaFuelFlowmeterAccuracyDataProps,
   qaCycleTimeSummaryProps,
+  qaTransmitterTransducerAccuracyDataProps,
 } from "../../../additional-functions/qa-dataTable-props";
 import {
   attachChangeEventListeners,
@@ -723,6 +724,26 @@ const QATestSummaryDataTable = ({
             radioBtnPayload={cycleTimeSum["radioBtnPayload"]}
             dataTableName={cycleTimeSum["dataTableName"]}
             extraControls={cycleTimeSum["extraControls"]}
+            expandable
+            {...props}
+            extraIDs={null}
+            user={user}
+            isCheckedOut={isCheckedOut}
+          />
+        );
+      case "TTACC":
+        const transmitterTransducerAccuracyDataProps = qaTransmitterTransducerAccuracyDataProps();
+        return (
+          <QAExpandableRowsRender
+            payload={transmitterTransducerAccuracyDataProps["payload"]}
+            dropdownArray={transmitterTransducerAccuracyDataProps["dropdownArray"]}
+            mdmProps={transmitterTransducerAccuracyDataProps["mdmProps"]}
+            columns={transmitterTransducerAccuracyDataProps["columnNames"]}
+            controlInputs={transmitterTransducerAccuracyDataProps["controlInputs"]}
+            controlDatePickerInputs={transmitterTransducerAccuracyDataProps["controlDatePickerInputs"]}
+            radioBtnPayload={transmitterTransducerAccuracyDataProps["radioBtnPayload"]}
+            dataTableName={transmitterTransducerAccuracyDataProps["dataTableName"]}
+            extraControls={transmitterTransducerAccuracyDataProps["extraControls"]}
             expandable
             {...props}
             extraIDs={null}

--- a/src/utils/api/dataManagementApi.js
+++ b/src/utils/api/dataManagementApi.js
@@ -489,3 +489,10 @@ export const getAllAccuracyTestMethodCodes = async () => {
     .then(handleResponse)
     .catch(handleError);
 }
+
+export const getAllAccuracySpecCodes = async () => {
+  return axios
+    .get(`${config.services.mdm.uri}/accuracy-spec-codes`)
+    .then(handleResponse)
+    .catch(handleError);
+}

--- a/src/utils/api/qaCertificationsAPI.js
+++ b/src/utils/api/qaCertificationsAPI.js
@@ -1648,3 +1648,69 @@ export const deleteFuelFlowmeterAccuracyDataRecord = async (
     return handleImportError(error);
   }
 };
+
+export const getTransmitterTransducerAccuracyDataRecords = async (locId, testSumId) => {
+  const path = `/locations/${locId}/test-summary/${testSumId}/transmitter-transducer-accuracy`;
+  const url = getApiUrl(path);
+  return axios.get(url).then(handleResponse).catch(handleError);
+};
+
+export const createTransmitterTransducerAccuracyDataRecord = async (
+  locId,
+  testSumId,
+  payload
+) => {
+  const path = `/locations/${locId}/test-summary/${testSumId}/transmitter-transducer-accuracy`;
+  const url = getApiUrl(path);
+  try {
+    return handleResponse(
+      await secureAxios({
+        method: "POST",
+        url: url,
+        data: payload,
+      })
+    );
+  } catch (error) {
+    return handleImportError(error);
+  }
+};
+
+export const updateTransmitterTransducerAccuracyDataRecord = async (
+  locId,
+  testSumId,
+  id,
+  payload
+) => {
+  const path = `/locations/${locId}/test-summary/${testSumId}/transmitter-transducer-accuracy/${id}`;
+  const url = getApiUrl(path);
+  try {
+    return handleResponse(
+      await secureAxios({
+        method: "PUT",
+        url: url,
+        data: payload,
+      })
+    );
+  } catch (error) {
+    return handleImportError(error);
+  }
+};
+
+export const deleteTransmitterTransducerAccuracyDataRecord = async (
+  locId,
+  testSumId,
+  id
+) => {
+  const path = `/locations/${locId}/test-summary/${testSumId}/transmitter-transducer-accuracy/${id}`;
+  const url = getApiUrl(path);
+  try {
+    return handleResponse(
+      await secureAxios({
+        method: "DELETE",
+        url: url,
+      })
+    );
+  } catch (error) {
+    return handleImportError(error);
+  }
+};

--- a/src/utils/api/qaCertificationsApi.test.js
+++ b/src/utils/api/qaCertificationsApi.test.js
@@ -551,7 +551,69 @@ describe("QA Cert API", function () {
     });
   })
  
+  describe("Transmitter Transducer Accuracy Data CRUD operations", () => {
+    test("getTransmitterTransducerAccuracyDataRecords", async () => {
+      const transmitterTransducerAccuracyDataResp = [
+        { transmitterTransducerAccuracyData: "data" },
+        { transmitterTransducerAccuracyData: "data2" },
+      ];
+      const getTransmitterTransducerAccuracyDataUrl = `${qaCertBaseUrl}/locations/${locId}/test-summary/${testSumId}/transmitter-transducer-accuracy`;
+      mock.onGet(getTransmitterTransducerAccuracyDataUrl).reply(200, transmitterTransducerAccuracyDataResp);
 
+      const resp = await qaCert.getTransmitterTransducerAccuracyDataRecords(
+        locId,
+        testSumId,
+      );
+
+      expect(mock.history.get.length).toBe(1);
+      expect(resp.data).toStrictEqual(transmitterTransducerAccuracyDataResp);
+    });
+
+    test("createTransmitterTransducerAccuracyDataRecord", async () => {
+      const payload = { transmitterTransducerAccuracyData: "data" };
+      const postTransmitterTransducerAccuracyDataUrl = `${qaCertBaseUrl}/locations/${locId}/test-summary/${testSumId}/transmitter-transducer-accuracy`;
+      mock.onPost(postTransmitterTransducerAccuracyDataUrl).reply(200, payload);
+
+      const resp = await qaCert.createTransmitterTransducerAccuracyDataRecord(
+        locId,
+        testSumId,
+        payload
+      );
+
+      expect(mock.history.post.length).toBe(1);
+      expect(resp.data).toStrictEqual(payload);
+    });
+
+    test("updateTransmitterTransducerAccuracyDataRecord", async () => {
+      const payload = { transmitterTransducerAccuracyData: "data" };
+      const putTransmitterTransducerAccuracyDataUrl = `${qaCertBaseUrl}/locations/${locId}/test-summary/${testSumId}/transmitter-transducer-accuracy/${id}`;
+      mock.onPut(putTransmitterTransducerAccuracyDataUrl).reply(200, payload);
+
+      const resp = await qaCert.updateTransmitterTransducerAccuracyDataRecord(
+        locId,
+        testSumId,
+        id,
+        payload
+      );
+
+      expect(mock.history.put.length).toBe(1);
+      expect(resp.data).toStrictEqual(payload);
+    });
+
+    test("deleteTransmitterTransducerAccuracyDataRecord", async () => {
+      const deleteTransmitterTransducerAccuracyDataUrl = `${qaCertBaseUrl}/locations/${locId}/test-summary/${testSumId}/transmitter-transducer-accuracy/${id}`;
+      mock.onDelete(deleteTransmitterTransducerAccuracyDataUrl).reply(200, "deleted");
+
+      const resp = await qaCert.deleteTransmitterTransducerAccuracyDataRecord(
+        locId,
+        testSumId,
+        id
+      );
+
+      expect(mock.history.delete.length).toBe(1);
+      expect(resp.data).toStrictEqual("deleted");
+    });
+  });
 
 
   

--- a/src/utils/selectors/QACert/TestSummary.js
+++ b/src/utils/selectors/QACert/TestSummary.js
@@ -472,6 +472,23 @@ export const mapFuelFlowmeterAccuracyDataToRows = (data) => {
   return records;
 };
 
+export const mapTransmitterTransducerAccuracyDataToRows = (data) => {
+  const records = [];
+  for (const el of data) {
+    const row = {
+      id: el.id,
+      col1: el.lowLevelAccuracy,
+      col2: el.lowLevelAccuracySpecCode,
+      col3: el.midLevelAccuracy,
+      col4: el.midLevelAccuracySpecCode,
+      col5: el.highLevelAccuracy,
+      col6: el.highLevelAccuracySpecCode,
+    };
+    records.push(row);
+  }
+  return records;
+};
+
 export const mapOnOffCalToRows = (data) => {
   const records = [];
   for (const el of data) {

--- a/src/utils/selectors/QACert/TestSummary.test.js
+++ b/src/utils/selectors/QACert/TestSummary.test.js
@@ -428,4 +428,29 @@ describe("testing TestSummary data selectors", () => {
     ];
     expect(fs.mapFuelFlowmeterAccuracyDataToRows(data)).toEqual(records);
   });
+  test("mapTransmitterTransducerAccuracyDataToRows", () => {
+    const data = [
+      {
+        id: "0000120",
+        lowLevelAccuracy: 1,
+        lowLevelAccuracySpecCode: "ACT",
+        midLevelAccuracy: 1,
+        midLevelAccuracySpecCode: "ACT",
+        highLevelAccuracy: 1,
+        highLevelAccuracySpecCode: "ACT",
+      },
+    ];
+    const records = [
+      {
+        id: '0000120',
+        col1: 1,
+        col2: "ACT",
+        col3: 1,
+        col4: "ACT",
+        col5: 1,
+        col6: "ACT",
+      },
+    ];
+    expect(fs.mapTransmitterTransducerAccuracyDataToRows(data)).toEqual(records);
+  });
 });

--- a/src/utils/selectors/QACert/assert.js
+++ b/src/utils/selectors/QACert/assert.js
@@ -24,7 +24,8 @@ const flowToLoadCheck = "Flow To Load Check";
 const onlineOfflineCalibration = "Online Offline Calibration";
 const calibrationInjections = "Calibration Injection";
 const fuelFlowmeterAccuracyData = "Fuel Flowmeter Accuracy Data";
-const cycleTimeSummary = "Cycle Time Summary"
+const cycleTimeSummary = "Cycle Time Summary";
+const transmitterTransducerAccuracyData = "Transmitter Transducer Accuracy Data";
 
 // Getting records from API
 export const getDataTableApis = async (name, location, id, extraIdsArr) => {
@@ -166,6 +167,12 @@ export const getDataTableApis = async (name, location, id, extraIdsArr) => {
       .catch((error) => {
         console.log("error", error);
       })  
+    case transmitterTransducerAccuracyData:
+      return qaApi
+      .getTransmitterTransducerAccuracyDataRecords(location, id)
+      .catch((error) => {
+        console.log("error", error);
+      })  
     default:
       throw new Error(`getDataTableApis case not implemented for ${name}`);
   }
@@ -216,6 +223,8 @@ export const getDataTableRecords = (dataIn, name) => {
       return selector.mapFuelFlowmeterAccuracyDataToRows(dataIn);
     case cycleTimeSummary:
       return selector.mapCycleTimeSummariesToRows(dataIn);
+    case transmitterTransducerAccuracyData:
+      return selector.mapTransmitterTransducerAccuracyDataToRows(dataIn);
     default:
       throw new Error(`getDataTableRecords case not implemented for ${name}`);
   }
@@ -373,6 +382,10 @@ export const removeDataSwitch = async (
     case cycleTimeSummary:
       return qaApi
         .deleteCycleTimeSummary(locationId, id, row.id)
+        .catch((error) => console.log("error", error));
+    case transmitterTransducerAccuracyData:
+      return qaApi
+        .deleteTransmitterTransducerAccuracyDataRecord(locationId, id, row.id)
         .catch((error) => console.log("error", error));
     default:
       throw new Error(`removeDataSwitch case not implemented for ${name}`);
@@ -566,6 +579,13 @@ export const saveDataSwitch = (userInput, name, location, id, extraIdsArr) => {
         userInput.id, 
         userInput
         ).catch((err) => console.error(err));
+    case transmitterTransducerAccuracyData:
+      return qaApi.updateTransmitterTransducerAccuracyDataRecord(
+        location,
+        id,
+        userInput.id,
+        userInput
+      ).catch((err) => console.error(err));
     default:
       break;
   }
@@ -720,9 +740,11 @@ export const createDataSwitch = async (
     case calibrationInjections:
       return qaApi.createCalibrationInjectionRecord(location, id, userInput);
     case fuelFlowmeterAccuracyData:
-      return qaApi.createFuelFlowmeterAccuracyDataRecord(location, id, userInput)
+      return qaApi.createFuelFlowmeterAccuracyDataRecord(location, id, userInput);
     case cycleTimeSummary:
-      return qaApi.createCycleTimeSummary(location, id, userInput)
+      return qaApi.createCycleTimeSummary(location, id, userInput);
+    case transmitterTransducerAccuracyData:
+      return qaApi.createTransmitterTransducerAccuracyDataRecord(location, id, userInput);
     default:
       throw new Error(`createDataSwitch case not implemented for ${name}`);
   }

--- a/src/utils/selectors/QACert/assert.test.js
+++ b/src/utils/selectors/QACert/assert.test.js
@@ -21,6 +21,7 @@ const testQualification = "Test Qualification";
 const appendixECorrHeatInputOil = "Appendix E Correlation Heat Input from Oil";
 const fuelFlowmeterAccuracyData = "Fuel Flowmeter Accuracy Data";
 const cycleTimeSummary = "Cycle Time Summary";
+const transmitterTransducerAccuracyData = "Transmitter Transducer Accuracy Data";
 // below types don't have coverage if needed more
 const flowToLoadCheck = "Flow To Load Check";
 const lineInjection = "Linearity Injection";
@@ -379,6 +380,83 @@ describe("Fuel Flowmeter Accuracy Data CRUD operations", () => {
     const resp = await qaAssert.removeDataSwitch(
       {id: id},
       fuelFlowmeterAccuracyData,
+      locId,
+      testSumId,
+      extraIDs
+    )
+
+    expect(mock.history.delete.length).toBe(1);
+    expect(resp.data).toStrictEqual("deleted");
+  });
+});
+
+describe("Transmitter Transducer Accuracy Data CRUD operations", () => {
+  beforeEach(() => {
+    mock.resetHistory();
+  });
+  test("getTransmitterTransducerAccuracyDataRecords", async () => {
+    const transmitterTransducerAccuracyDataRecord = [
+      { transmitterTransducerAccuracyData: "data" },
+    ];
+    const getTransmitterTransducerAccuracyDataUrl = `${qaCertBaseUrl}/locations/${locId}/test-summary/${testSumId}/transmitter-transducer-accuracy`;
+    mock
+      .onGet(getTransmitterTransducerAccuracyDataUrl)
+      .reply(200, transmitterTransducerAccuracyDataRecord);
+    const extraIDs = [locId,testSumId];
+    const resp = await qaAssert.getDataTableApis(
+      transmitterTransducerAccuracyData,
+      locId,
+      testSumId,
+      extraIDs
+    )
+
+    expect(mock.history.get.length).toBe(1);
+    expect(resp.data).toStrictEqual(transmitterTransducerAccuracyDataRecord);
+  });
+
+  test("createTransmitterTransducerAccuracyDataRecord", async () => {
+    const payload = { transmitterTransducerAccuracyData: "data" };
+    const postTransmitterTransducerAccuracyDataUrl = `${qaCertBaseUrl}/locations/${locId}/test-summary/${testSumId}/transmitter-transducer-accuracy`;
+    mock.onPost(postTransmitterTransducerAccuracyDataUrl).reply(200, "success");
+    const extraIDs = [locId,testSumId];
+    const resp = await qaAssert.createDataSwitch(
+      payload,
+      transmitterTransducerAccuracyData,
+      locId,
+      testSumId,
+      extraIDs
+    )
+
+    expect(mock.history.post.length).toBe(1);
+    expect(resp.data).toStrictEqual("success");
+  });
+
+  test("updateTransmitterTransducerAccuracyDataRecord", async () => {
+    const payload = { id:id, transmitterTransducerAccuracyData: "data" };
+    const putTransmitterTransducerAccuracyDataUrl = `${qaCertBaseUrl}/locations/${locId}/test-summary/${testSumId}/transmitter-transducer-accuracy/${id}`;
+    mock.onPut(putTransmitterTransducerAccuracyDataUrl).reply(200, "success");
+
+    const extraIDs = [locId,testSumId];
+    const resp = await qaAssert.saveDataSwitch(
+      payload,
+      transmitterTransducerAccuracyData,
+      locId,
+      testSumId,
+      extraIDs
+    )
+
+    expect(mock.history.put.length).toBe(1);
+    expect(resp.data).toStrictEqual("success");
+  });
+
+  test("deleteTransmitterTransducerAccuracyDataRecord", async () => {
+    const deleteTransmitterTransducerAccuracyDataUrl = `${qaCertBaseUrl}/locations/${locId}/test-summary/${testSumId}/transmitter-transducer-accuracy/${id}`;
+    mock.onDelete(deleteTransmitterTransducerAccuracyDataUrl).reply(200, "deleted");
+    
+    const extraIDs = [locId,testSumId];
+    const resp = await qaAssert.removeDataSwitch(
+      {id: id},
+      transmitterTransducerAccuracyData,
       locId,
       testSumId,
       extraIDs


### PR DESCRIPTION
As an ECMPS user, I want to view Transmitter Transducer Accuracy Data in the Global View, add new Transmitter Transducer Accuracy Data in the Workspace so that I can look at real-time data or add test information as needed, update Transmitter Transducer Accuracy Data so that I can add information to a test, and remove Transmitter Transducer Accuracy Data so that I can update data as needed.