### PR TITLE
Bug Fix: Pre-populate StackPipeId Field

### DIFF
--- a/src/components/qaDatatablesContainer/QATestSummaryDataTable/QATestSummaryDataTable.js
+++ b/src/components/qaDatatablesContainer/QATestSummaryDataTable/QATestSummaryDataTable.js
@@ -347,6 +347,7 @@ const QATestSummaryDataTable = ({
           selectedLocation.name,
           "fixed",
         ];
+        selectedData.stackPipeId = selectedLocation.name;
       }
       selectedData.locationName = selectedLocation.name;
       // default selection to single test type code if it exists


### PR DESCRIPTION
ReadOnly "Unit or Stack Pipe ID" was only being pre-populated if a UnitID was selected.  This fixes bug so a selected StackPipe ID will be prepopulated as well.