### PR TITLE
Bug/4539 disable preview button on export page for emissions

### DIFF
--- a/src/components/export/ExportTab/ExportTab.js
+++ b/src/components/export/ExportTab/ExportTab.js
@@ -143,6 +143,19 @@ export const ExportTab = ({
     );
   };
 
+  const isPreviewDisabled = ()=>{
+
+    const checkedDataTypes = dataTypes.filter(e=>e.checked);
+
+    // if only qa is checked
+    if( checkedDataTypes.length === 1 && checkedDataTypes[0].name === qa){
+
+      return false;
+    }
+    
+    return true;
+  }
+
   return (
     <>
       {loading ? <Preloader /> : null}
@@ -184,11 +197,7 @@ export const ExportTab = ({
             <Button
               type={"button"}
               className="width-card"
-              disabled={
-                dataTypes.filter((e) => e.checked).length === 0 ||
-                (dataTypes.filter((e) => e.checked).length === 1 &&
-                  dataTypes.find((e) => e.name === mp).checked)
-              }
+              disabled={isPreviewDisabled()}
               onClick={() =>
                 setPreviewOptions({
                   beginDate: reportingPeriod.beginDate,

--- a/src/components/export/ExportTab/ExportTab.test.js
+++ b/src/components/export/ExportTab/ExportTab.test.js
@@ -4,6 +4,8 @@ import { render, screen } from "@testing-library/react";
 import { act } from "react-dom/test-utils";
 import { getReportingPeriod, selectedConfig } from "./ExportTab.test.mocks";
 import userEvent from "@testing-library/user-event";
+import { fireEvent } from "@testing-library/react/dist/pure";
+import { before } from "lodash";
 
 describe("ExportTab", function () {
   let emissionsApi;
@@ -61,5 +63,52 @@ describe("ExportTab", function () {
         )
       );
     });
+
+    describe("Testing Preview Button", ()=>{
+      
+      let mpCheckboxElement;
+      let emissionsCheckboxElement;
+      let qaCheckboxElement;
+      let previewButtonElement;
+
+      beforeEach(async ()=>{
+        await act(async () => {
+          return render(
+            <ExportTab
+              orisCode={3}
+              exportState={null}
+              setExportState={() => null}
+              workspaceSection={"export"}
+              selectedConfig={selectedConfig}
+              facility={"Barry (1, 2, CS0AAN)"}
+            />
+          );
+        });
+
+        mpCheckboxElement = screen.getByLabelText("Monitoring Plan");
+        emissionsCheckboxElement = screen.getByLabelText("Emissions");
+        qaCheckboxElement = screen.getByLabelText("QA & Certification");                  
+        previewButtonElement = screen.getByRole("button", {name: "Preview"});
+      })
+
+      it("should render the component with the preview button disabled", ()=>{
+        expect(previewButtonElement.disabled).toBe(true)
+      })
+
+      it("should disable preview button when MP is checked", ()=>{  
+        fireEvent.click(mpCheckboxElement)
+        expect(previewButtonElement.disabled).toBe(true)
+      })
+      
+      it("should disable preview button when Emissions is checked", ()=>{
+        fireEvent.click(emissionsCheckboxElement)
+        expect(previewButtonElement.disabled).toBe(true)
+      })
+
+      it("should enable preview button when QA is checked", async ()=>{
+        fireEvent.click(qaCheckboxElement)
+        expect(previewButtonElement.disabled).toBe(false)
+      })
+    })
   });
 });


### PR DESCRIPTION
## Pull Request

* Disables preview button for emissions 
* Added tests around when Preview is enabled/disabled
