### PR TITLE
Added edit and remove functionality to Unit Default Test

### DIFF
--- a/src/utils/api/qaCertificationsAPI.js
+++ b/src/utils/api/qaCertificationsAPI.js
@@ -1838,7 +1838,8 @@ export const createUnitDefaultTest = async (
   testSumId,
   payload
 ) => {
-  const url = `${config.services.qaCertification.uri}/workspace/locations/${locId}/test-summary/${testSumId}/unit-default-tests`;
+  const path = `/locations/${locId}/test-summary/${testSumId}/unit-default-tests`;
+  const url = getApiUrl(path);
   try {
     return handleResponse(
       await secureAxios({
@@ -1852,4 +1853,42 @@ export const createUnitDefaultTest = async (
     }
 };
 
+export const updateUnitDefaultTest = async (
+  locId,
+  testSumId,
+  id,
+  payload
+) => {
+  const path = `/locations/${locId}/test-summary/${testSumId}/unit-default-tests/${id}`;
+  const url = getApiUrl(path);
+  try {
+    return handleResponse(
+      await secureAxios({
+        method: "PUT",
+        url: url,
+        data: payload,
+      })
+    );
+  } catch (error) {
+    return handleImportError(error);
+  }
+};
 
+export const deleteUnitDefaultTest = async (
+  locId,
+  testSumId,
+  id
+) => {
+  const path = `/locations/${locId}/test-summary/${testSumId}/unit-default-tests/${id}`;
+  const url = getApiUrl(path);
+  try {
+    return handleResponse(
+      await secureAxios({
+        method: "DELETE",
+        url: url,
+      })
+    );
+  } catch (error) {
+    return handleImportError(error);
+  }
+};

--- a/src/utils/api/qaCertificationsApi.test.js
+++ b/src/utils/api/qaCertificationsApi.test.js
@@ -681,6 +681,69 @@ describe("QA Cert API", function () {
     });
   });
 
+  describe("Unit Default Test Data CRUD operations", () => {
+    test("getUnitDefaultTest", async () => {
+      const unitDefaultTestResp = [
+        { unitDefaultTest: "data" },
+        { unitDefaultTest: "data2" },
+      ];
+      const getUnitDefaultTestUrl = `${qaCertBaseUrl}/locations/${locId}/test-summary/${testSumId}/unit-default-tests`;
+      mock.onGet(getUnitDefaultTestUrl).reply(200, unitDefaultTestResp);
+
+      const resp = await qaCert.getUnitDefaultTest(
+        locId,
+        testSumId,
+      );
+
+      expect(mock.history.get.length).toBe(1);
+      expect(resp.data).toStrictEqual(unitDefaultTestResp);
+    });
+
+    test("createUnitDefaultTest", async () => {
+      const payload = { unitDefaultTest: "data" };
+      const postUnitDefaultTestUrl = `${qaCertBaseUrl}/locations/${locId}/test-summary/${testSumId}/unit-default-tests`;
+      mock.onPost(postUnitDefaultTestUrl).reply(200, payload);
+
+      const resp = await qaCert.createUnitDefaultTest(
+        locId,
+        testSumId,
+        payload
+      );
+
+      expect(mock.history.post.length).toBe(1);
+      expect(resp.data).toStrictEqual(payload);
+    });
+
+    test("updateUnitDefaultTest", async () => {
+      const payload = { unitDefaultTest: "data" };
+      const putUnitDefaultTestUrl = `${qaCertBaseUrl}/locations/${locId}/test-summary/${testSumId}/unit-default-tests/${id}`;
+      mock.onPut(putUnitDefaultTestUrl).reply(200, payload);
+
+      const resp = await qaCert.updateUnitDefaultTest(
+        locId,
+        testSumId,
+        id,
+        payload
+      );
+
+      expect(mock.history.put.length).toBe(1);
+      expect(resp.data).toStrictEqual(payload);
+    });
+
+    test("deleteUnitDefaultTest", async () => {
+      const deleteUnitDefaultTestUrl = `${qaCertBaseUrl}/locations/${locId}/test-summary/${testSumId}/unit-default-tests/${id}`;
+      mock.onDelete(deleteUnitDefaultTestUrl).reply(200, "deleted");
+
+      const resp = await qaCert.deleteUnitDefaultTest(
+        locId,
+        testSumId,
+        id
+      );
+
+      expect(mock.history.delete.length).toBe(1);
+      expect(resp.data).toStrictEqual("deleted");
+    });
+  });
 
   
   /*

--- a/src/utils/selectors/QACert/assert.js
+++ b/src/utils/selectors/QACert/assert.js
@@ -421,6 +421,10 @@ export const removeDataSwitch = async (
       return qaApi
         .deleteFlowToLoadReference(locationId, id, row.id)
         .catch(error => console.log("error deleting flow to load reference", error))
+    case unitDefualtTest:
+      return qaApi
+        .deleteUnitDefaultTest(locationId, id, row.id)
+        .catch((error) => console.log("error", error));
     default:
       throw new Error(`removeDataSwitch case not implemented for ${name}`);
   }
@@ -632,6 +636,9 @@ export const saveDataSwitch = (userInput, name, location, id, extraIdsArr) => {
         userInput.id,
         userInput
       ).catch(error => console.log("error updating flow to load reference", error))
+    case unitDefualtTest:
+      return qaApi.updateUnitDefaultTest(location, id, userInput.id, userInput)
+        .catch((err) => console.error(err));
     default:
       break;
   }

--- a/src/utils/selectors/QACert/assert.test.js
+++ b/src/utils/selectors/QACert/assert.test.js
@@ -27,6 +27,7 @@ const flowToLoadCheck = "Flow To Load Check";
 const lineInjection = "Linearity Injection";
 const rataData = "RATA Data";
 const airEmissions = "Air Emissions";
+const unitDefualtTest = "Unit Default Test";
 
 describe("Test Qualification CRUD operations", () => {
   beforeEach(() => {
@@ -765,6 +766,84 @@ describe("Air Emissions CRUD operations", () => {
     const resp = await qaAssert.removeDataSwitch(
       {id: id},
       airEmissions,
+      locId,
+      testSumId,
+      extraIDs
+    )
+
+    expect(mock.history.delete.length).toBe(1);
+    expect(resp.data).toStrictEqual("deleted");
+  });
+});
+
+
+describe("Unit Default CRUD operations", () => {
+  beforeEach(() => {
+    mock.resetHistory();
+  });
+  test("getUnitDefaultTest", async () => {
+    const unitDefaultTestObject = [
+      { unitDefaultTest: "data" },
+    ];
+    const getUnitDefaultTestUrl = `${qaCertBaseUrl}/locations/${locId}/test-summary/${testSumId}/unit-default-tests`;
+    mock
+      .onGet(getUnitDefaultTestUrl)
+      .reply(200, unitDefaultTestObject);
+    const extraIDs = [locId,testSumId];
+    const resp = await qaAssert.getDataTableApis(
+      unitDefualtTest,
+      locId,
+      testSumId,
+      extraIDs
+    )
+
+    expect(mock.history.get.length).toBe(1);
+    expect(resp.data).toStrictEqual(unitDefaultTestObject);
+  });
+
+  test("createUnitDefaultTest", async () => {
+    const payload = { unitDefaultTest: "data" };
+    const postUnitDefaultTestUrl = `${qaCertBaseUrl}/locations/${locId}/test-summary/${testSumId}/unit-default-tests`;
+    mock.onPost(postUnitDefaultTestUrl).reply(200, "success");
+    const extraIDs = [locId,testSumId];
+    const resp = await qaAssert.createDataSwitch(
+      payload,
+      unitDefualtTest,
+      locId,
+      testSumId,
+      extraIDs
+    )
+
+    expect(mock.history.post.length).toBe(1);
+    expect(resp.data).toStrictEqual("success");
+  });
+
+  test("updateUnitDefaultTest", async () => {
+    const payload = { id:id, unitDefaultTest: "data" };
+    const putUnitDefaultTestUrl = `${qaCertBaseUrl}/locations/${locId}/test-summary/${testSumId}/unit-default-tests/${id}`;
+    mock.onPut(putUnitDefaultTestUrl).reply(200, "success");
+
+    const extraIDs = [locId,testSumId];
+    const resp = await qaAssert.saveDataSwitch(
+      payload,
+      unitDefualtTest,
+      locId,
+      testSumId,
+      extraIDs
+    )
+
+    expect(mock.history.put.length).toBe(1);
+    expect(resp.data).toStrictEqual("success");
+  });
+
+  test("deleteUnitDefaultTest", async () => {
+    const deleteUnitDefaultTestUrl = `${qaCertBaseUrl}/locations/${locId}/test-summary/${testSumId}/unit-default-tests/${id}`;
+    mock.onDelete(deleteUnitDefaultTestUrl).reply(200, "deleted");
+
+    const extraIDs = [locId,testSumId];
+    const resp = await qaAssert.removeDataSwitch(
+      {id: id},
+      unitDefualtTest,
       locId,
       testSumId,
       extraIDs


### PR DESCRIPTION
As an ECMPS user (logged-in), I want to update Unit Default Test data so that I can add information to a test

As an ECMPS user, I want the ability to remove Unit Default Test Data so that I can update data as needed