### PR TITLE
Fix Bug in HeaderInfo when No currentTab

### DIFF
--- a/src/components/HeaderInfo/HeaderInfo.js
+++ b/src/components/HeaderInfo/HeaderInfo.js
@@ -218,7 +218,7 @@ export const HeaderInfo = ({
   useEffect(()=>{
 
     // this would mean reporting peruiods were already selected and users are probably just switching back to the tab, so their selctions should remain.
-    if( currentTab?.reportingPeriods ){
+    if( currentTab === undefined || currentTab?.reportingPeriods ){
       return
     }
     
@@ -246,7 +246,7 @@ export const HeaderInfo = ({
   // Adding dispatch to below dep array causes an inifinte rerender problem
   // hence why the linter warning is being suppressed.
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [reportingPeriods, currentTab.name, workspaceSection])
+  }, [reportingPeriods, currentTab, workspaceSection])
   
   useEffect(() => {
     if (currentTab?.viewTemplateSelect)

--- a/src/components/MonitoringPlanTab/MonitoringPlanTab.test.js
+++ b/src/components/MonitoringPlanTab/MonitoringPlanTab.test.js
@@ -6,7 +6,6 @@ import {
 } from "./MonitoringPlanTab";
 import { render } from "@testing-library/react";
 import { MONITORING_PLAN_STORE_NAME } from "../../additional-functions/workspace-section-and-store-names";
-jest.mock("../../store/actions/dynamicFacilityTab");
 import * as actions from "../../store/actions/dynamicFacilityTab";
 
 // jest.mock("../../store/actions/activeTab");
@@ -16,6 +15,8 @@ import { Provider } from "react-redux";
 import configureStore from "../../store/configureStore.dev";
 const store = configureStore();
 const axios = require("axios");
+
+jest.mock("../../store/actions/dynamicFacilityTab");
 jest.mock("axios");
 
 test("should render without throwing an error", async () => {
@@ -51,7 +52,6 @@ test("should render without throwing an error", async () => {
           retireDate: null,
         },
       ],
-      unitStackConfigurations: [],
       endReportPeriodId: "24",
       active: false,
       unitStackConfigurations: [


### PR DESCRIPTION
Recent changes to HeaderInfo introduced a bug when there is no "currentTab", causing a couple of unit tests to fail