### PR TITLE
Feature/2951 add view hg summary

### DIFF
--- a/src/additional-functions/qa-dataTable-props.js
+++ b/src/additional-functions/qa-dataTable-props.js
@@ -1032,3 +1032,35 @@ export const qaUnitDefaultTestDataProps = () => {
     controlDatePickerInputs: {},
   }
 }
+
+export const qaHgSummaryDataProps = () => {
+  return {
+    dataTableName: "Hg Summary",
+    payload: {},
+    dropdownArray: ["gasLevelCode"],
+    mdmProps: [
+      {
+        codeTable: "gas-level-codes",
+        responseProps: {
+          code: "gasLevelCode",
+          description: "gasLevelDescription"
+        }
+      },
+    ],
+    columnNames: [
+      "Gas Level Code",
+      "Mean Measured Value",
+      "Mean Reference Value",
+      "Percent Error",
+      "APS Indicator",
+    ],
+    controlInputs: {
+      gasLevelCode: ["Gas Level Code", "dropdown", "", ""],
+      meanMeasuredValue: ["Mean Measured Value", "input", "", ""],
+      meanReferenceValue: ["Mean Reference Value", "input", "", ""],
+      percentError: ["Percent Error", "input", "", ""],
+      apsIndicator: ["APS Indicator", "radio", "", ""],
+    },
+    controlDatePickerInputs: {},
+  }
+}

--- a/src/components/export/ExportTab/ExportTab.test.js
+++ b/src/components/export/ExportTab/ExportTab.test.js
@@ -24,6 +24,7 @@ describe("ExportTab", function () {
 
   describe("Emissions Export", function () {
     it("should enable export button when the emissions checkbox is checked, and download when export is clicked", async function () {
+      jest.setTimeout(10000);
       jest
         .spyOn(qaCertificationsApi, "getReportingPeriod")
         .mockResolvedValue(getReportingPeriod);
@@ -108,6 +109,7 @@ describe("ExportTab", function () {
       it("should enable preview button when QA is checked", async ()=>{
         fireEvent.click(qaCheckboxElement)
         expect(previewButtonElement.disabled).toBe(false)
+        jest.setTimeout(5000);
       })
     })
   });

--- a/src/components/qaDatatablesContainer/QAExpandableRowsRender/QAExpandableRowsRender.test.js
+++ b/src/components/qaDatatablesContainer/QAExpandableRowsRender/QAExpandableRowsRender.test.js
@@ -28,7 +28,8 @@ import {
   qaCycleTimeSummaryProps,
   qaCycleTimeInjectionProps,
   qaFlowToLoadReferenceProps,
-  qaUnitDefaultTestDataProps
+  qaUnitDefaultTestDataProps,
+  qaHgSummaryDataProps
 } from "../../../additional-functions/qa-dataTable-props";
 
 const mock = new MockAdapter(axios);
@@ -1453,6 +1454,74 @@ describe('Test cases for QAExpandableRowsRender', () => {
     // saveAndCloseBtn = screen.getByRole('button', { name: /Click to save/i })
     // userEvent.click(saveAndCloseBtn)
 
+  })
+
+  test('renders Hg Summary data rows and create/save/delete', async () => {
+    const hgSummaryData = [
+      {
+        "id": "id1",
+        "testSumId": "testSumId1",
+        "gasLevelCode": "Mid",
+        "meanMeasuredValue": 1,
+        "meanReferenceValue": 1,
+        "percentError": 1,
+        "apsIndicator": 1,
+      },
+      {
+        "id": "id2",
+        "testSumId": "testSumId2",
+        "gasLevelCode": "High",
+        "meanMeasuredValue": 2,
+        "meanReferenceValue": 2,
+        "percentError": 2,
+        "apsIndicator": 2,
+      },
+    ]
+  
+    const getUrl = `${qaCertBaseUrl}/locations/${locId}/test-summary/${testSumId}/hg-summaries`;
+    const postUrl = `${qaCertBaseUrl}/workspace/locations/${locId}/test-summary/${testSumId}/hg-summaries`;
+    const putUrl = new RegExp(`${qaCertBaseUrl}/workspace/locations/${locId}/test-summary/${testSumId}/hg-summaries/${idRegex}`);
+    const deleteUrl = new RegExp(`${qaCertBaseUrl}/workspace/locations/${locId}/test-summary/${testSumId}/hg-summaries/${idRegex}`);
+  
+    const gasLevelCodesURl = 'https://api.epa.gov/easey/dev/master-data-mgmt/gas-level-codes'
+    mock.onGet(gasLevelCodesURl).reply(200, [])
+  
+    mock.onGet(getUrl).reply(200, hgSummaryData)
+    mock.onPost(postUrl).reply(200, 'created')
+    mock.onPut(putUrl).reply(200, 'updated')
+    mock.onDelete(deleteUrl).reply(200, 'deleted')
+
+    const props = qaHgSummaryDataProps()
+    const idArray = [locId, testSumId]
+    const data = { locationId: locId, id: testSumId }
+    renderComponent(props, idArray, data);
+
+    // renders rows
+    const rows = await screen.findAllByRole('row')
+    expect(mock.history.get.length).not.toBe(0)
+    expect(rows).toHaveLength(hgSummaryData.length)
+
+    // add row
+    const addBtn = screen.getByRole('button', { name: /Add/i })
+    userEvent.click(addBtn)
+    let saveAndCloseBtn = screen.getByRole('button', { name: /Click to save/i })
+    userEvent.click(saveAndCloseBtn)
+    setTimeout(() => expect(mock.history.post.length).toBe(1), 1000)
+
+    // edit row
+    const editBtns = screen.getAllByRole('button', { name: /Edit/i })
+    expect(editBtns).toHaveLength(hgSummaryData.length)
+    userEvent.click(editBtns[0])
+    saveAndCloseBtn = screen.getByRole('button', { name: /Click to save/i })
+    userEvent.click(saveAndCloseBtn)
+    setTimeout(() => expect(mock.history.put.length).toBe(1), 1000)
+
+    const deleteBtns = await screen.getAllByRole('button', { name: /Remove/i })
+    expect(deleteBtns).toHaveLength(hgSummaryData.length)
+    const secondDeleteBtn = deleteBtns[1]
+    userEvent.click(secondDeleteBtn)
+    const confirmBtns = screen.getAllByRole('button', { name: /Yes/i })
+    userEvent.click(confirmBtns[1])
   })
 })
 

--- a/src/components/qaDatatablesContainer/QATestSummaryDataTable/QATestSummaryDataTable.js
+++ b/src/components/qaDatatablesContainer/QATestSummaryDataTable/QATestSummaryDataTable.js
@@ -25,6 +25,7 @@ import {
   qaTransmitterTransducerAccuracyDataProps,
   qaFlowToLoadReferenceProps,
   qaUnitDefaultTestDataProps,
+  qaHgSummaryDataProps,
 } from "../../../additional-functions/qa-dataTable-props";
 import {
   attachChangeEventListeners,
@@ -806,6 +807,23 @@ const QATestSummaryDataTable = ({
             columns={unitDefaultTestDataProps["columnNames"]}
             controlInputs={unitDefaultTestDataProps["controlInputs"]}
             dataTableName={unitDefaultTestDataProps["dataTableName"]}
+            expandable
+            {...props}
+            extraIDs={null}
+            user={user}
+            isCheckedOut={isCheckedOut}
+          />
+        );
+      case "HGL3LS": //Hg Linearity and 3-Level Summary
+        const hgSummaryDataProps = qaHgSummaryDataProps();
+        return (
+          <QAExpandableRowsRender
+            payload={hgSummaryDataProps["payload"]}
+            dropdownArray={hgSummaryDataProps["dropdownArray"]}
+            mdmProps={hgSummaryDataProps["mdmProps"]}
+            columns={hgSummaryDataProps["columnNames"]}
+            controlInputs={hgSummaryDataProps["controlInputs"]}
+            dataTableName={hgSummaryDataProps["dataTableName"]}
             expandable
             {...props}
             extraIDs={null}

--- a/src/components/qaDatatablesContainer/QATestSummaryDataTable/QATestSummaryDataTable.test.js
+++ b/src/components/qaDatatablesContainer/QATestSummaryDataTable/QATestSummaryDataTable.test.js
@@ -621,6 +621,12 @@ test("testing component renders properly with FFL ", async () => {
   );
   expect(container).toBeDefined();
 });
+test("testing component renders properly with HGL3LS ", async () => {
+  const { container } = await waitForElement(() =>
+    componentRender(true, "HGL3LS")
+  );
+  expect(container).toBeDefined();
+});
 test("testing component renders properly with default ", async () => {
   const { container } = await waitForElement(() =>
     componentRender(true, "default")

--- a/src/utils/api/qaCertificationsAPI.js
+++ b/src/utils/api/qaCertificationsAPI.js
@@ -1892,3 +1892,69 @@ export const deleteUnitDefaultTest = async (
     return handleImportError(error);
   }
 };
+
+export const getHgSummary = async (locId, testSumId) => {
+  const path = `/locations/${locId}/test-summary/${testSumId}/hg-summaries`;
+  const url = getApiUrl(path);
+  return axios.get(url).then(handleResponse).catch(handleError);
+};
+
+export const createHgSummary = async (
+  locId,
+  testSumId,
+  payload
+) => {
+  const path = `/locations/${locId}/test-summary/${testSumId}/hg-summaries`;
+  const url = getApiUrl(path);
+  try {
+    return handleResponse(
+      await secureAxios({
+        method: "POST",
+        url: url,
+        data: payload,
+      })
+      );
+    } catch (error) {
+      return handleImportError(error);
+    }
+};
+
+export const updateHgSummary = async (
+  locId,
+  testSumId,
+  id,
+  payload
+) => {
+  const path = `/locations/${locId}/test-summary/${testSumId}/hg-summaries/${id}`;
+  const url = getApiUrl(path);
+  try {
+    return handleResponse(
+      await secureAxios({
+        method: "PUT",
+        url: url,
+        data: payload,
+      })
+    );
+  } catch (error) {
+    return handleImportError(error);
+  }
+};
+
+export const deleteHgSummary = async (
+  locId,
+  testSumId,
+  id
+) => {
+  const path = `/locations/${locId}/test-summary/${testSumId}/hg-summaries/${id}`;
+  const url = getApiUrl(path);
+  try {
+    return handleResponse(
+      await secureAxios({
+        method: "DELETE",
+        url: url,
+      })
+    );
+  } catch (error) {
+    return handleImportError(error);
+  }
+};

--- a/src/utils/api/qaCertificationsApi.test.js
+++ b/src/utils/api/qaCertificationsApi.test.js
@@ -745,6 +745,70 @@ describe("QA Cert API", function () {
     });
   });
 
+  describe("Hg Summary Data CRUD operations", () => {
+    test("getHgSummary", async () => {
+      const hgSummaryResp = [
+        { hgSummary: "data" },
+        { hgSummary: "data2" },
+      ];
+      const getHgSummaryUrl = `${qaCertBaseUrl}/locations/${locId}/test-summary/${testSumId}/hg-summaries`;
+      mock.onGet(getHgSummaryUrl).reply(200, hgSummaryResp);
+
+      const resp = await qaCert.getHgSummary(
+        locId,
+        testSumId,
+      );
+
+      expect(mock.history.get.length).toBe(1);
+      expect(resp.data).toStrictEqual(hgSummaryResp);
+    });
+
+    test("createHgSummary", async () => {
+      const payload = { hgSummary: "data" };
+      const postHgSummaryUrl = `${qaCertBaseUrl}/locations/${locId}/test-summary/${testSumId}/hg-summaries`;
+      mock.onPost(postHgSummaryUrl).reply(200, payload);
+
+      const resp = await qaCert.createHgSummary(
+        locId,
+        testSumId,
+        payload
+      );
+
+      expect(mock.history.post.length).toBe(1);
+      expect(resp.data).toStrictEqual(payload);
+    });
+
+    test("updateHgSummary", async () => {
+      const payload = { hgSummary: "data" };
+      const putHgSummaryUrl = `${qaCertBaseUrl}/locations/${locId}/test-summary/${testSumId}/hg-summaries/${id}`;
+      mock.onPut(putHgSummaryUrl).reply(200, payload);
+
+      const resp = await qaCert.updateHgSummary(
+        locId,
+        testSumId,
+        id,
+        payload
+      );
+
+      expect(mock.history.put.length).toBe(1);
+      expect(resp.data).toStrictEqual(payload);
+    });
+
+    test("deleteHgSummary", async () => {
+      const deleteHgSummaryUrl = `${qaCertBaseUrl}/locations/${locId}/test-summary/${testSumId}/hg-summaries/${id}`;
+      mock.onDelete(deleteHgSummaryUrl).reply(200, "deleted");
+
+      const resp = await qaCert.deleteHgSummary(
+        locId,
+        testSumId,
+        id
+      );
+
+      expect(mock.history.delete.length).toBe(1);
+      expect(resp.data).toStrictEqual("deleted");
+    });
+  });
+
   
   /*
   describe("Review And Submit", () => {

--- a/src/utils/selectors/QACert/TestSummary.js
+++ b/src/utils/selectors/QACert/TestSummary.js
@@ -574,6 +574,22 @@ export const mapUnitDefaultTestDataToRows = (data) => {
   return records;
 }
 
+export const mapHgSummaryDataToRows = (data) => {
+  const records = [];
+  for (const el of data) {
+    const row = {
+      id: el.id,
+      col1: el.gasLevelCode,
+      col2: el.meanMeasuredValue,
+      col3: el.meanReferenceValue,
+      col4: el.percentError,
+      col5: el.apsIndicator,
+    };
+    records.push(row)
+  }
+  return records;
+}
+
 
 export const getListOfRadioControls = (controlInputs) => {
   const result = [];

--- a/src/utils/selectors/QACert/TestSummary.test.js
+++ b/src/utils/selectors/QACert/TestSummary.test.js
@@ -548,9 +548,9 @@ describe("testing TestSummary data selectors", () => {
       {
         id: "0000120",
         gasLevelCode: "Mid",
-        meanMeasuredValue: "string",
-        meanReferenceValue: "string",
-        percentError: "string",
+        meanMeasuredValue: 1,
+        meanReferenceValue: 1,
+        percentError: .1,
         apsIndicator: 1,
       },
     ];
@@ -558,9 +558,9 @@ describe("testing TestSummary data selectors", () => {
       {
         id: '0000120',
         col1: "Mid",
-        col2: "string",
-        col3: "string",
-        col4: "string",
+        col2: 1,
+        col3: 1,
+        col4: .1,
         col5: 1,
       },
     ];

--- a/src/utils/selectors/QACert/TestSummary.test.js
+++ b/src/utils/selectors/QACert/TestSummary.test.js
@@ -543,4 +543,27 @@ describe("testing TestSummary data selectors", () => {
     ];
     expect(fs.mapTransmitterTransducerAccuracyDataToRows(data)).toEqual(records);
   });
+  test("mapHgSummaryDataToRows", () => {
+    const data = [
+      {
+        id: "0000120",
+        gasLevelCode: "Mid",
+        meanMeasuredValue: "string",
+        meanReferenceValue: "string",
+        percentError: "string",
+        apsIndicator: 1,
+      },
+    ];
+    const records = [
+      {
+        id: '0000120',
+        col1: "Mid",
+        col2: "string",
+        col3: "string",
+        col4: "string",
+        col5: 1,
+      },
+    ];
+    expect(fs.mapHgSummaryDataToRows(data)).toEqual(records);
+  });
 });

--- a/src/utils/selectors/QACert/assert.js
+++ b/src/utils/selectors/QACert/assert.js
@@ -30,6 +30,7 @@ const cycleTimeInjection = "Cycle Time Injection";
 const transmitterTransducerAccuracyData = "Transmitter Transducer Accuracy Data";
 const flowToLoadReference = "Flow To Load Reference";
 const unitDefualtTest = "Unit Default Test";
+const hgSummary = "Hg Summary";
 
 // Getting records from API
 export const getDataTableApis = async (name, location, id, extraIdsArr) => {
@@ -191,6 +192,10 @@ export const getDataTableApis = async (name, location, id, extraIdsArr) => {
       return qaApi.getUnitDefaultTest(location, id).catch((error) => {
         console.log("error fetching unit default test data", error);
       });
+    case hgSummary:
+      return qaApi.getHgSummary(location, id).catch((error) => {
+        console.log("error", error);
+      });
     default:
       throw new Error(`getDataTableApis case not implemented for ${name}`);
   }
@@ -249,6 +254,8 @@ export const getDataTableRecords = (dataIn, name) => {
       return selector.mapFlowToLoadReferenceToRows(dataIn);
     case unitDefualtTest:
       return selector.mapUnitDefaultTestDataToRows(dataIn);
+    case hgSummary:
+      return selector.mapHgSummaryDataToRows(dataIn);
     default:
       throw new Error(`getDataTableRecords case not implemented for ${name}`);
   }
@@ -424,6 +431,10 @@ export const removeDataSwitch = async (
     case unitDefualtTest:
       return qaApi
         .deleteUnitDefaultTest(locationId, id, row.id)
+        .catch((error) => console.log("error", error));
+    case hgSummary:
+      return qaApi
+        .deleteHgSummary(locationId, id, row.id)
         .catch((error) => console.log("error", error));
     default:
       throw new Error(`removeDataSwitch case not implemented for ${name}`);
@@ -639,6 +650,9 @@ export const saveDataSwitch = (userInput, name, location, id, extraIdsArr) => {
     case unitDefualtTest:
       return qaApi.updateUnitDefaultTest(location, id, userInput.id, userInput)
         .catch((err) => console.error(err));
+    case hgSummary:
+      return qaApi.updateHgSummary(location, id, userInput.id, userInput)
+        .catch((err) => console.error(err));
     default:
       break;
   }
@@ -810,6 +824,8 @@ export const createDataSwitch = async (
       return qaApi.createFlowToLoadReference(location, id, userInput)
     case unitDefualtTest:
       return qaApi.createUnitDefaultTest(location, id, userInput)
+    case hgSummary:
+      return qaApi.createHgSummary(location, id, userInput)
     default:
       throw new Error(`createDataSwitch case not implemented for ${name}`);
   }

--- a/src/utils/selectors/QACert/assert.test.js
+++ b/src/utils/selectors/QACert/assert.test.js
@@ -28,6 +28,7 @@ const lineInjection = "Linearity Injection";
 const rataData = "RATA Data";
 const airEmissions = "Air Emissions";
 const unitDefualtTest = "Unit Default Test";
+const hgSummary = "Hg Summary";
 
 describe("Test Qualification CRUD operations", () => {
   beforeEach(() => {
@@ -844,6 +845,83 @@ describe("Unit Default CRUD operations", () => {
     const resp = await qaAssert.removeDataSwitch(
       {id: id},
       unitDefualtTest,
+      locId,
+      testSumId,
+      extraIDs
+    )
+
+    expect(mock.history.delete.length).toBe(1);
+    expect(resp.data).toStrictEqual("deleted");
+  });
+});
+
+describe("Hg Summary CRUD operations", () => {
+  beforeEach(() => {
+    mock.resetHistory();
+  });
+  test("getHgSummary", async () => {
+    const hgSummaryObject = [
+      { hgSummary: "data" },
+    ];
+    const getHgSummaryUrl = `${qaCertBaseUrl}/locations/${locId}/test-summary/${testSumId}/hg-summaries`;
+    mock
+      .onGet(getHgSummaryUrl)
+      .reply(200, hgSummaryObject);
+    const extraIDs = [locId,testSumId];
+    const resp = await qaAssert.getDataTableApis(
+      hgSummary,
+      locId,
+      testSumId,
+      extraIDs
+    )
+
+    expect(mock.history.get.length).toBe(1);
+    expect(resp.data).toStrictEqual(hgSummaryObject);
+  });
+
+  test("createHgSummary", async () => {
+    const payload = { hgSummary: "data" };
+    const postHgSummaryUrl = `${qaCertBaseUrl}/locations/${locId}/test-summary/${testSumId}/hg-summaries`;
+    mock.onPost(postHgSummaryUrl).reply(200, "success");
+    const extraIDs = [locId,testSumId];
+    const resp = await qaAssert.createDataSwitch(
+      payload,
+      hgSummary,
+      locId,
+      testSumId,
+      extraIDs
+    )
+
+    expect(mock.history.post.length).toBe(1);
+    expect(resp.data).toStrictEqual("success");
+  });
+
+  test("updateHgSummary", async () => {
+    const payload = { id:id, hgSummary: "data" };
+    const putHgSummaryUrl = `${qaCertBaseUrl}/locations/${locId}/test-summary/${testSumId}/hg-summaries/${id}`;
+    mock.onPut(putHgSummaryUrl).reply(200, "success");
+
+    const extraIDs = [locId,testSumId];
+    const resp = await qaAssert.saveDataSwitch(
+      payload,
+      hgSummary,
+      locId,
+      testSumId,
+      extraIDs
+    )
+
+    expect(mock.history.put.length).toBe(1);
+    expect(resp.data).toStrictEqual("success");
+  });
+
+  test("deleteHgSummary", async () => {
+    const deleteHgSummaryUrl = `${qaCertBaseUrl}/locations/${locId}/test-summary/${testSumId}/hg-summaries/${id}`;
+    mock.onDelete(deleteHgSummaryUrl).reply(200, "deleted");
+
+    const extraIDs = [locId,testSumId];
+    const resp = await qaAssert.removeDataSwitch(
+      {id: id},
+      hgSummary,
       locId,
       testSumId,
       extraIDs


### PR DESCRIPTION
As an ECMPS user, I want to view Hg Linearity and 3-level Summary Data in the Global-View and add new Hg Linearity and 3-level Summary Data in the Workspace so that I can look at real-time data or add test information as needed

As an ECMPS user (logged-in), I want to update Hg Summary data so that I can add information to a test

As an ECMPS user, I want the ability to remove Hg Summary data so that I can update data as needed

