### PR TITLE
Fixed view issue with apsIndicator

### DIFF
--- a/src/utils/selectors/QACert/TestSummary.js
+++ b/src/utils/selectors/QACert/TestSummary.js
@@ -583,7 +583,7 @@ export const mapHgSummaryDataToRows = (data) => {
       col2: el.meanMeasuredValue,
       col3: el.meanReferenceValue,
       col4: el.percentError,
-      col5: el.apsIndicator,
+      col5: el.apsIndicator === 1 ? "Yes" : "No",
     };
     records.push(row)
   }

--- a/src/utils/selectors/QACert/TestSummary.test.js
+++ b/src/utils/selectors/QACert/TestSummary.test.js
@@ -561,7 +561,7 @@ describe("testing TestSummary data selectors", () => {
         col2: 1,
         col3: 1,
         col4: .1,
-        col5: 1,
+        col5: "Yes",
       },
     ];
     expect(fs.mapHgSummaryDataToRows(data)).toEqual(records);


### PR DESCRIPTION
As an ECMPS user, I want to view Hg Linearity and 3-level Summary Data in the Global-View and add new Hg Linearity and 3-level Summary Data in the Workspace so that I can look at real-time data or add test information as needed