### PR TITLE
🐛 Bug/4727: Monitoring SYS ID and Component ID not populating when Editing

### DIFF
--- a/src/additional-functions/qa-dataTable-props.js
+++ b/src/additional-functions/qa-dataTable-props.js
@@ -1414,8 +1414,8 @@ export const qaCertEventsProps = (selectedLocation) => {
     payload: {
       id: null,
       unitId: null,
-      monitoringSystemID: null,
-      componentID: null,
+      monitoringSystemID: "string",
+      componentID: "string",
       qaCertEventCode: null,
       requiredTestCode: null,
       qaCertEventHour: null,
@@ -1494,8 +1494,8 @@ export const qaTestExemptionProps = (selectedLocation) => {
     payload: {
       id: null,
       unitId: null,
-      monitoringSystemID: null,
-      componentID: null,
+      monitoringSystemID: "string",
+      componentID: 'string',
       year: null,
       quarter: null,
       hoursUsed: null,

--- a/src/components/qaDatatablesContainer/QACertEventTestExmpDataTable/QACertEventTestExmpDataTable.js
+++ b/src/components/qaDatatablesContainer/QACertEventTestExmpDataTable/QACertEventTestExmpDataTable.js
@@ -457,7 +457,6 @@ const QACertEventTestExmpDataTable = ({
   };
 
   const saveData = async (row) => {
-    let selectedData = {};
     const userInput = extractUserInput(payload, ".modalUserInput");
 
     assertSelector
@@ -485,6 +484,7 @@ const QACertEventTestExmpDataTable = ({
       userInput.stackPipeId = String(userInput.stackPipeId);
       userInput.unitId = null;
     }
+    
     assertSelector
       .createDataSwitch(userInput, dataTableName, locationSelectValue)
       .then((res) => {

--- a/src/utils/selectors/QACert/assert.js
+++ b/src/utils/selectors/QACert/assert.js
@@ -777,11 +777,11 @@ export const saveDataSwitch = (userInput, name, location, id, extraIdsArr) => {
     // for some reason, id and userinput. id are identical in the url
     case qaCertEvent:
       return qaApi
-        .updateQaCertEvents(id, userInput.id, userInput)
+        .updateQaCertEvents(location, id, userInput)
         .catch((error) => console.log("error updating QA cert events", error));
     case qaExeptions:
       return qaApi
-        .updateTestExtension(id, userInput.id, userInput)
+        .updateTestExtension(location, id, userInput)
         .catch((error) =>
           console.log("error updating QA TEST EXCEPTIONS", error)
         );


### PR DESCRIPTION
## 🐛 [Bug/4727: Monitoring SYS ID and Component ID not populating when Editing](https://app.zenhub.com/workspaces/emissioners-scrum-board-5f36cd263511ad001a777f8e/issues/gh/us-epa-camd/easey-ui/4727)