### PR TITLE
🐛 Bug/4727: Monitoring SYS ID and Component ID not populating when Editing

### DIFF
--- a/src/components/qaDatatablesContainer/QACertEventTestExmpDataTable/QACertEventTestExmpDataTable.js
+++ b/src/components/qaDatatablesContainer/QACertEventTestExmpDataTable/QACertEventTestExmpDataTable.js
@@ -476,7 +476,7 @@ const QACertEventTestExmpDataTable = ({
   };
 
   const createData = () => {
-    const userInput = extractUserInput({}, ".modalUserInput");
+    const userInput = extractUserInput(payload, ".modalUserInput");
     if (userInput.unitId) {
       userInput.unitId = String(userInput.unitId);
       userInput.stackPipeId = null;


### PR DESCRIPTION
## 🐛 [Bug/4727: Monitoring SYS ID and Component ID not populating when Editing](https://app.zenhub.com/workspaces/emissioners-scrum-board-5f36cd263511ad001a777f8e/issues/gh/us-epa-camd/easey-ui/4727)