### PR TITLE
fixed issue with miscellaneous test summaries

### DIFF
--- a/src/components/qaDatatablesContainer/QATestSummaryDataTable/QATestSummaryDataTable.js
+++ b/src/components/qaDatatablesContainer/QATestSummaryDataTable/QATestSummaryDataTable.js
@@ -88,6 +88,7 @@ const QATestSummaryDataTable = ({
 
   const [allTestTypeCodes, setAllTestTypeCodes] = useState(null);
   const selectText = '-- Select a value --';
+  const miscellaneousTestTypes = ['DAHS','LEAK','OTHER','PEMSACC','DGFMCAL','MFMCAL','BCAL','QGA','TSCAL']
   //*****
   // pull these out and make components reuseable like monitoring plan
   const [dropdownArray, setDropdownArray] = useState([
@@ -258,8 +259,14 @@ const QATestSummaryDataTable = ({
     // Update all the "secondary dropdowns" (based on the "main" dropdown)
     const prefilteredDataName = dropdownArray[0][0];
     if (prefilteredMdmData) {
+      let currentTestTypeCode;
+      if(mainDropdownChange === '' || (selectedTestCode.testTypeCodes[0] !== 'DAHS' && miscellaneousTestTypes.includes(mainDropdownChange))){
+        currentTestTypeCode = selectedTestCode.testTypeCodes[0]
+      } else {
+        currentTestTypeCode = mainDropdownChange
+      }
       const result = prefilteredMdmData.filter(
-        (prefiltered) => prefiltered[prefilteredDataName] === selectedTestCode.testTypeCodes[0]
+        (prefiltered) => prefiltered[prefilteredDataName] === currentTestTypeCode
       );
 
       if (result.length > 0) {


### PR DESCRIPTION
As an ECMPS user, I want the options in the Test Reason and Result Code dropdown restricted so that I can choose from applicable options

Acceptance Criteria:
Given I am creating Test Data for any of the Test Data types in the attached document
I want the Test Reason Code and Test Result Code dropdown options restricted to the applicable options

https://app.zenhub.com/files/287570343/22315a08-c8d2-4c8b-800e-8e006fe24986/download

Note: Check that we are using the relationships API endpoint for Reason and Result Code (Test Summaries Relationship API)

Extension & exemption codes mdm endpoint:
https://api.epa.gov/easey/dev/master-data-mgmt/extension-exemption-codes