### PR TITLE
Feature/4796 table header focus

### DIFF
--- a/src/additional-scss/_react-datatable-component-override.scss
+++ b/src/additional-scss/_react-datatable-component-override.scss
@@ -39,6 +39,11 @@
       :hover:not(:focus) {
         color: $epa-black !important;
       }
+      :focus {
+        .MuiSvgIcon-root {
+          opacity: 1;
+        }
+      }
     }
     border: none !important;
   }


### PR DESCRIPTION
Locations: Any tables/grid in ECMPS
Issues:

Table headers do not have an up/down arrow visible on focus only on mouseover (Select Configurations Screen: Tab to the Header and the Sort arrow needs to be visible)
The fix needs to be implemented for both Logged-in and Global-view and across ECMPS (MP, QA, Emissions, Export etc wherever we have tables with Sort)