### PR TITLE
removed aria-sort none

### DIFF
--- a/src/additional-functions/ensure-508.js
+++ b/src/additional-functions/ensure-508.js
@@ -218,7 +218,7 @@ export const addInitialAriaSort = () => {
         } else {
           column
             .closest(`.rdt_TableCol_Sortable`)
-            .setAttribute("aria-sort", "none");
+            .removeAttribute("aria-sort");
         }
       }
     });
@@ -247,7 +247,7 @@ export const setAriaSort = (event) => {
     // *** make sure aria-sort attribute is set
     document.querySelectorAll(`.rdt_TableCol_Sortable`).forEach((column) => {
       if (column === currentColumn) {
-        if (currentColumn.ariaSort === "none") {
+        if (!currentColumn.ariaSort) {
           if (sortIcon && sortIcon.classList) {
             if (sortIcon.classList.contains("asc")) {
               currentColumn.ariaSort = "ascending";
@@ -263,7 +263,7 @@ export const setAriaSort = (event) => {
           }
         }
       } else {
-        column.ariaSort = "none";
+        column.removeAttribute("aria-sort");
       }
     });
   }


### PR DESCRIPTION
The following issues were flagged on the CAMPD 508 scan by EPA. All tables throughout the website (MP, QA, Emissions, Export etc) should mirror the behavior of the table on https://campd.epa.gov/data/bulk-data-files

Logged in and Logged Out:

Don't put aria sort until it is sorted by ascending/descending (so remove aria sort=none, only set aria sort when the column is set to ascending or descending)