### PR TITLE
Feature/4814 default test type code

### DIFF
--- a/src/components/qaDatatablesContainer/QATestSummaryDataTable/QATestSummaryDataTable.js
+++ b/src/components/qaDatatablesContainer/QATestSummaryDataTable/QATestSummaryDataTable.js
@@ -227,10 +227,12 @@ const QATestSummaryDataTable = ({
             }
           });
         }
-        dropdowns[dropdownArray[0][i]].unshift({
-          code: '',
-          name: '-- Select a value --',
-        });
+        if(i !== 0){
+          dropdowns[dropdownArray[0][i]].unshift({
+            code: '',
+            name: '-- Select a value --',
+          });
+        }
       });
       setMdmData(dropdowns);
       setDropdownsLoaded(true);


### PR DESCRIPTION
As an ECMPS user, I want the Test Type Code dropdown to display the applicable default option so that I know which Test Data I am adding

Acceptance Criteria:
Given I am an ECMPS user adding Test Data
When I click on 'Add' for Test Data
Then I see that the Test Type Code dropdown displays the default applicable option (Based on what Test Type Code screen the user is on)