### PR TITLE
Bug/4816 flow to load bug

### DIFF
--- a/src/utils/api/dataManagementApi.js
+++ b/src/utils/api/dataManagementApi.js
@@ -1,6 +1,7 @@
 import axios from "axios";
 import { handleResponse, handleError } from "./apiUtils";
 import config from "../../config";
+import { secureAxios } from "./easeyAuthApi";
 
 axios.defaults.headers.common = {
   "x-api-key": config.app.apiKey,
@@ -450,7 +451,7 @@ export const getAllMonitoringSystemIDCodes = async (locationId) => {
   }
 
   let monitoringSystemUrl = `${url}/locations/${locationId}/systems`;
-  return axios.get(monitoringSystemUrl).then((response) => {
+  return secureAxios({method: "GET", url: monitoringSystemUrl}).then((response) => {
     const actualResponse = response;
     const dataArray = [];
     response.data.map((monitorCode) => {
@@ -514,7 +515,14 @@ export const getAllCalculatedSeparateReferenceIndicatorCodes = async () => {
 export const getRataTestNumber = async (locationId) => {
   const testSummaryUrl = `https://api.epa.gov/easey/dev/qa-certification-mgmt/locations/${locationId}/test-summary?testTypeCodes=RATA&systemTypeCodes=FLOW`
   const testSummaryWorkspaceUrl = `https://api.epa.gov/easey/dev/qa-certification-mgmt/workspace/locations/${locationId}/test-summary?testTypeCodes=RATA&systemTypeCodes=FLOW`
-  const testSummaries = await Promise.all([axios.get(testSummaryUrl), axios.get(testSummaryWorkspaceUrl)])
+  const testSummaries = await Promise.all([
+    secureAxios({
+      method: "GET",
+      url: testSummaryUrl,
+    }), secureAxios({
+      method: "GET",
+      url: testSummaryWorkspaceUrl,
+    })])
   const allTestSummaries = [...testSummaries[0].data, ...testSummaries[1].data]
   const rataTestNumbers = allTestSummaries.map(testSummary => {
     const testNumber = testSummary.testNumber


### PR DESCRIPTION
Issue:
User is unable to add Flow to Load Reference data or Appendix E heat input from OIL

Steps to Recreate:

Log into ECMPS
Check out a config (ex. Barry 1,2,CS0AAN)
Select Flow to Load Reference Test Type Group or Appendix E
Expand a test summary
Click on Add for Flow to Load Reference data or Appendix E heat input from OIL
The system doesn't open the Add modal