### PR TITLE
Bug/4820 add modal not closing

### DIFF
--- a/src/components/qaDatatablesContainer/QAExpandableRowsRender/QAExpandableRowsRender.js
+++ b/src/components/qaDatatablesContainer/QAExpandableRowsRender/QAExpandableRowsRender.js
@@ -939,6 +939,7 @@ const QAExpandableRowsRender = ({
       if (resp.status === 201) {
         setCreatedDataId(resp.data.id);
         setUpdateTable(true);
+        executeOnClose();
       } else {
         const errorResp = Array.isArray(resp) ? resp : [resp];
         setErrorMsgs(errorResp);


### PR DESCRIPTION
When creating any record in QA other than a test summary, the Add modal doesn't close when data is added