### PR TITLE
Fixed contrast on add button

### DIFF
--- a/src/additional-scss/_react-datatable-component-override.scss
+++ b/src/additional-scss/_react-datatable-component-override.scss
@@ -32,9 +32,6 @@
         border: solid 4px #2672de;
         color: $epa-black !important;
       }
-      :hover:not(:focus) {
-        color: $epa-black !important;
-      }
       :focus {
         .MuiSvgIcon-root {
           opacity: 1;


### PR DESCRIPTION
Issue:
When add buttons have focus in the QA Module (Test Data and QA Cert and TEE Data), text color changes to black, and the contrast is low

Note: Update similar to contrast on the Edit buttons