### PR TITLE
Fixed color on add button focus

### DIFF
--- a/src/additional-scss/_react-datatable-component-override.scss
+++ b/src/additional-scss/_react-datatable-component-override.scss
@@ -30,7 +30,7 @@
       :focus {
         outline: none;
         border: solid 4px #2672de;
-        color: $epa-black !important;
+        //color: $epa-black !important;
       }
       :focus {
         .MuiSvgIcon-root {


### PR DESCRIPTION
Issue:
When add buttons have focus in the QA Module (Test Data and QA Cert and TEE Data), text color changes to black, and the contrast is low

Note: Update similar to contrast on the Edit buttons