### PR TITLE
Feature/4835 update focus

### DIFF
--- a/src/components/datatablesContainer/DataTableAssert/DataTableAssert.js
+++ b/src/components/datatablesContainer/DataTableAssert/DataTableAssert.js
@@ -360,6 +360,18 @@ export const DataTableAssert = ({
             });
             modalDetailData[6] = filteredOutSubDropdownOptions;
           }
+          
+          // Modal focus resets to close button on setState
+          if (modalDetailData[4] === "mainDropdown") {
+            // Overrides the firstComponentFocusableElement.focus() in focus-trap
+            setTimeout(() => {
+              document.getElementById(modalDetailData[1]).focus()
+            });
+            // Overrides the document.querySelector("#closeModalBtn").focus() in Modal
+            setTimeout(() => {
+              document.getElementById(modalDetailData[1]).focus()
+            }, 1000);
+          }
         }
       }
     }

--- a/src/components/datatablesContainer/DataTableMats/DataTableMats.js
+++ b/src/components/datatablesContainer/DataTableMats/DataTableMats.js
@@ -263,6 +263,18 @@ export const DataTableMats = ({
             // Load the filtered data into the dropdown
             modalDetailData[6] = filteredOutSubDropdownOptions;
           }
+          
+          // Modal focus resets to close button on setState
+          if (modalDetailData[4] === "mainDropdown") {
+            // Overrides the firstComponentFocusableElement.focus() in focus-trap
+            setTimeout(() => {
+              document.getElementById(modalDetailData[1]).focus()
+            });
+            // Overrides the document.querySelector("#closeModalBtn").focus() in Modal
+            setTimeout(() => {
+              document.getElementById(modalDetailData[1]).focus()
+            }, 1000);
+          }
         }
       }
     }

--- a/src/components/datatablesContainer/DataTableMethod/DataTableMethod.js
+++ b/src/components/datatablesContainer/DataTableMethod/DataTableMethod.js
@@ -204,6 +204,18 @@ export const DataTableMethod = ({
             // Load the filtered data into the dropdown
             modalDetailData[6] = filteredOutSubDropdownOptions;
           }
+          
+          // Modal focus resets to close button on setState
+          if (modalDetailData[4] === "mainDropdown") {
+            // Overrides the firstComponentFocusableElement.focus() in focus-trap
+            setTimeout(() => {
+              document.getElementById(modalDetailData[1]).focus()
+            });
+            // Overrides the document.querySelector("#closeModalBtn").focus() in Modal
+            setTimeout(() => {
+              document.getElementById(modalDetailData[1]).focus()
+            }, 1000);
+          }
         }
       }
     }


### PR DESCRIPTION
Issue:
MP Workspace - Create/Edit Modal - Making a parameter select shifts focus to the close button instead of keeping focus where it is.

Stepps to Recreate:

Login to ECMPS, navigate to MP an Select, checkout and open a Configuration
From the Section dropdown, Select Method
Click on View/Edit or Create Method to open the modal
Make a selection in the Parameter dropdown
Observe that the focus immediately goes to X. It should stay on the selection made for Parameter