### PR TITLE
feature / 4836 - Return Focus to View Comments Btn on Modal Close

### DIFF
--- a/src/additional-functions/manage-focus.js
+++ b/src/additional-functions/manage-focus.js
@@ -90,8 +90,9 @@ export const returnFocusToLast = () => {
 
 export const returnFocusToCommentButton = () => {
   if (!_.isNil(window["lastFocusedArray"])) {
-    const lastFocus =
-      window["lastFocusedArray"][window["lastFocusedArray"].length - 1];
+    const lastFocus = window["lastFocusedArray"]
+        .filter(o => o.innerHTML === 'View Comments')[0];
+    alert(lastFocus?.innerHTML);
     if (lastFocus) {
       lastFocus.focus();
     }


### PR DESCRIPTION
When closing the comments modal as a logged-in user, focus will now return to the "View Comments" button instead of the 
"Import Data" button.