### PR TITLE
feature / 4836 - Remove debugging alert

### DIFF
--- a/src/additional-functions/manage-focus.js
+++ b/src/additional-functions/manage-focus.js
@@ -92,7 +92,6 @@ export const returnFocusToCommentButton = () => {
   if (!_.isNil(window["lastFocusedArray"])) {
     const lastFocus = window["lastFocusedArray"]
         .filter(o => o.innerHTML === 'View Comments')[0];
-    alert(lastFocus?.innerHTML);
     if (lastFocus) {
       lastFocus.focus();
     }


### PR DESCRIPTION
Remove window.alert(...) that was mistakenly left in committed code.
