### PR TITLE
condition to only load dropdowns data if dropdownsArray is not empty

### DIFF
--- a/src/components/datatablesContainer/DataTableAssert/DataTableAssert.js
+++ b/src/components/datatablesContainer/DataTableAssert/DataTableAssert.js
@@ -199,8 +199,8 @@ export const DataTableAssert = ({
   };
 
   useEffect(() => {
-    // Load MDM data (for dropdowns) only if we don't have them already
-    if (mdmData && Object.keys(mdmData).length === 0) {
+    // Load MDM data (for dropdowns) only if dropdown is not empty and we don't have them already
+    if (!dropdownArrayIsEmpty && mdmData && Object.keys(mdmData).length === 0) {
       loadDropdownsData(dataTableName, dropdownArray);
     } else {
       setDropdownsLoaded(true);


### PR DESCRIPTION
When a user tries wishes to review (Global-view) or Add/Edit (Workspace) data for Unit Capacity, the Unit Capacity section doesn't load. The spinner keeps going