### PR TITLE
Bug/4954 error message inconsistency

### DIFF
--- a/src/additional-functions/app-error.js
+++ b/src/additional-functions/app-error.js
@@ -1,9 +1,10 @@
 export const needEndDate = "Must enter in both End Date and End Time";
 export const displayAppError = (error) => {
+  const formattedError = Array.isArray(error) ? error.join('\n') : error
   const appearAnimation = "flip-in-x-reverse";
 
   if (document.querySelector("#appErrorMessageText")) {
-    document.querySelector("#appErrorMessageText").innerHTML = error;
+    document.querySelector("#appErrorMessageText").innerHTML = formattedError;  
     document.querySelector("#appErrorMessage").classList.remove("display-none");
     document
       .querySelector("#appErrorMessage")

--- a/src/additional-functions/app-error.test.js
+++ b/src/additional-functions/app-error.test.js
@@ -36,6 +36,22 @@ describe("app error functions", () => {
     expect(test).toBeDefined();
   });
 
+  test('displays list of errors', () => {
+    const { container } = render(<Valid />);
+    const appErrorMessageTextEle = container.querySelector("#appErrorMessageText");
+    const errorMsgs = ['error1', 'error2', 'error3']
+
+    displayAppError(errorMsgs);
+
+    for (const msg of errorMsgs) {
+      expect(appErrorMessageTextEle).toHaveTextContent(msg);
+    }
+
+    hideAppError();
+
+    expect(appErrorMessageTextEle).toBeDefined();
+  })
+
   it("should test without a valid query", () => {
     const { container } = render(<Conditional />);
 

--- a/src/components/Layout/Layout.scss
+++ b/src/components/Layout/Layout.scss
@@ -36,6 +36,9 @@ div.row.column1 {
   color: #d10000;
   border-color: #d10000;
 }
+#appErrorMessageText {
+  white-space: pre-wrap;
+}
 .skip-to-content-link:focus {
   transform: translateY(0%);
 }

--- a/src/utils/api/apiUtils.js
+++ b/src/utils/api/apiUtils.js
@@ -42,7 +42,8 @@ export function handleError(error) {
       status: error.response.status,
       headers: error.response.headers,
     });
-    errorMessage = `${error.response.data?.error} ${error.response.data?.message}`;
+    // errorMessage = `${error.response.data?.error} ${error.response.data?.message}`;
+    errorMessage = error.response.data?.message
   } else if (error.request) {
     // client never received a response, or request never left
     log.error({ error: error.request });

--- a/src/utils/api/apiUtils.test.js
+++ b/src/utils/api/apiUtils.test.js
@@ -55,7 +55,7 @@ describe("test response and error handler functions", () => {
     const err4 = { message: "" };
 
     handleError(err1);
-    expect(globalMsg).toBe(`${errorName} ${firstErrorMsg}`);
+    expect(globalMsg).toBe(firstErrorMsg);
 
     handleError(err2);
     expect(globalMsg).toBe(apiErrorMsg);


### PR DESCRIPTION
Any error message being displayed on the ECMPS screens need to be formatted in a readable manner. For instance, a message where there are multiple errors combined and displayed in one go needs to be split to make it readable