### PR TITLE
Bug/4971 f2lref data fix

### DIFF
--- a/src/additional-functions/qa-dataTable-props.js
+++ b/src/additional-functions/qa-dataTable-props.js
@@ -1220,7 +1220,7 @@ export const qaFlowToLoadReferenceProps = () => {
     dropdownArray: [
       "rataTestNumber",
       "operatingLevelCode",
-      "calculatedSeparateReferenceIndicator",
+      "calcSeparateReferenceIndicator",
     ],
     // mdmProps: [
     //   {
@@ -1251,7 +1251,7 @@ export const qaFlowToLoadReferenceProps = () => {
         "",
         "",
       ],
-      referenceFlowToLoadRatio: ["Reference Flow Load Ratio", "input", "", ""],
+      referenceFlowLoadRatio: ["Reference Flow Load Ratio", "input", "", ""],
       averageHourlyHeatInputRate: [
         "Average Hourly Heat Input Rate",
         "input",
@@ -1259,7 +1259,7 @@ export const qaFlowToLoadReferenceProps = () => {
         "",
       ],
       referenceGrossHeatRate: ["Reference Gross Heat Rate", "input", "", ""],
-      calculatedSeparateReferenceIndicator: [
+      calcSeparateReferenceIndicator: [
         "Calculated Separate Reference Indicator",
         "dropdown",
         "",

--- a/src/components/qaDatatablesContainer/QAExpandableRowsRender/QAExpandableRowsRender.js
+++ b/src/components/qaDatatablesContainer/QAExpandableRowsRender/QAExpandableRowsRender.js
@@ -681,9 +681,9 @@ const QAExpandableRowsRender = ({
                   descriptionLabel = "opLevelDescription";
                   break;
                 case 2:
-                  codeLabel = "calculatedSeparateReferenceIndicatorCode";
+                  codeLabel = "calcSeparateReferenceIndicatorCode";
                   descriptionLabel =
-                    "calculatedSeparateReferenceIndicatorDescription";
+                    "calcSeparateReferenceIndicatorDescription";
                   break;
                 default:
                   break;

--- a/src/components/qaDatatablesContainer/QAExpandableRowsRender/QAExpandableRowsRender.test.js
+++ b/src/components/qaDatatablesContainer/QAExpandableRowsRender/QAExpandableRowsRender.test.js
@@ -1235,10 +1235,10 @@ describe('Test cases for QAExpandableRowsRender', () => {
         "operatingLevelCode": "string",
         "averageGrossUnitLoad": 0,
         "averageReferenceMethodFlow": 0,
-        "referenceFlowToLoadRatio": 0,
+        "referenceFlowLoadRatio": 0,
         "averageHourlyHeatInputRate": 0,
         "referenceGrossHeatRate": 0,
-        "calculatedSeparateReferenceIndicator": 0
+        "calcSeparateReferenceIndicator": 0
       },
       {
         "id": "id2",
@@ -1254,10 +1254,10 @@ describe('Test cases for QAExpandableRowsRender', () => {
         "operatingLevelCode": "string",
         "averageGrossUnitLoad": 0,
         "averageReferenceMethodFlow": 0,
-        "referenceFlowToLoadRatio": 0,
+        "referenceFlowLoadRatio": 0,
         "averageHourlyHeatInputRate": 0,
         "referenceGrossHeatRate": 0,
-        "calculatedSeparateReferenceIndicator": 0
+        "calcSeparateReferenceIndicator": 0
       }
     ]
 

--- a/src/utils/api/dataManagementApi.js
+++ b/src/utils/api/dataManagementApi.js
@@ -501,12 +501,12 @@ export const getAllAccuracySpecCodes = async () => {
 export const getAllCalculatedSeparateReferenceIndicatorCodes = async () => {
   const data = [
     {
-      calculatedSeparateReferenceIndicatorCode: '0',
-      calculatedSeparateReferenceIndicatorDescription: '0'
+      calcSeparateReferenceIndicatorCode: '0',
+      calcSeparateReferenceIndicatorDescription: '0'
     },
     {
-      calculatedSeparateReferenceIndicatorCode: '1',
-      calculatedSeparateReferenceIndicatorDescription: '1'
+      calcSeparateReferenceIndicatorCode: '1',
+      calcSeparateReferenceIndicatorDescription: '1'
     }
   ]
   return Promise.resolve({ status: 200, data })

--- a/src/utils/selectors/QACert/TestSummary.js
+++ b/src/utils/selectors/QACert/TestSummary.js
@@ -558,10 +558,10 @@ export const mapFlowToLoadReferenceToRows = (data) => {
       col2: el.operatingLevelCode,
       col3: el.averageGrossUnitLoad,
       col4: el.averageReferenceMethodFlow,
-      col5: el.referenceFlowToLoadRatio,
+      col5: el.referenceFlowLoadRatio,
       col6: el.averageHourlyHeatInputRate,
       col7: el.referenceGrossHeatRate,
-      col8: el.calculatedSeparateReferenceIndicator,
+      col8: el.calcSeparateReferenceIndicator,
     };
     records.push(row);
   }


### PR DESCRIPTION
file containing flowToLoadReferenceData don't import on the front end only generating errors "instance.testSummaryData[0].flowToLoadReferenceData[0] requires property "referenceFlowLoadRatio""
"instance.testSummaryData[0].flowToLoadReferenceData[0] requires property "calcSeparateReferenceIndicator""

The 2 values in the front end and backend don't match the correct schema name