### PR TITLE
fixed issue where strings would be treated as number

### DIFF
--- a/src/additional-functions/extract-user-input.js
+++ b/src/additional-functions/extract-user-input.js
@@ -52,12 +52,12 @@ export const extractUserInput = (payload, inputSelector, radios) => {
 
   payloadArray.forEach((item) => {
     if (item.value !== undefined) {
-      if (typeof item.value === "string" && isNaN(item.value)) {
+      if (typeof item.value === "string" && (isNaN(item.value) || (item.value.length > 1 && item.value.charAt(0) === '0'))) {
         payload[item.name] =
           item.value.trim() === "" ? null : item.value.trim();
       }
       // is a number
-      if (typeof item.value === "string" && !isNaN(item.value)) {
+      else if (typeof item.value === "string" && !isNaN(item.value)) {
         if (payload[item.name] === "string") {
           payload[item.name] =
             item.value.trim() === "" ? null : item.value.trim();


### PR DESCRIPTION
When adding Test Summary Data for QA Tests, when a user selects a value for the Component ID from the available options and creates the records, the selection is not saved. The selection when saved needs to be displayed both in the Test Data grid as well as the Edit modal, but currently, these are empty