### PR TITLE
Bug/4977 mp module date issue

### DIFF
--- a/src/additional-functions/extract-user-input.js
+++ b/src/additional-functions/extract-user-input.js
@@ -48,7 +48,6 @@ export const extractUserInput = (payload, inputSelector, radios) => {
     }
   }
 
-  // payloadArray.forEach((item) => {
   for (const item of payloadArray) {
     if (item.value === null || item.value === "") {
       payload[item.name] = null

--- a/src/additional-functions/extract-user-input.js
+++ b/src/additional-functions/extract-user-input.js
@@ -1,6 +1,4 @@
 export const extractUserInput = (payload, inputSelector, radios) => {
-
-  console.log('payload', payload)
   // *** construct payload
   const payloadInputs = document.querySelectorAll(inputSelector);
   const datepickerPayloads = document.querySelectorAll(
@@ -50,7 +48,12 @@ export const extractUserInput = (payload, inputSelector, radios) => {
     }
   }
 
-  payloadArray.forEach((item) => {
+  // payloadArray.forEach((item) => {
+  for (const item of payloadArray) {
+    if (item.value === null || item.value === "") {
+      payload[item.name] = null
+      continue;
+    }
     if (item.value !== undefined) {
       if (typeof item.value === "string" && (isNaN(item.value) || (item.value.length > 1 && item.value.charAt(0) === '0'))) {
         payload[item.name] =
@@ -77,7 +80,48 @@ export const extractUserInput = (payload, inputSelector, radios) => {
         }
       }
     }
-  });
+  }
 
   return payload;
 };
+
+export const validateUserInput = (userInput, options = {}) => {
+  const errors = []
+  const { dataTableName, lAttr, rDat } = options
+  const needsEndDateTime = 'Must enter in both End Date and Time'
+
+  checkFormulaBeginDateAndHour(userInput, errors, dataTableName);
+
+  // checks end date and hour for formula table
+  if (options.dataTableName === "Formula") {
+    if(userInput.endHour === null || !userInput.endDate){
+      errors.push(needsEndDateTime)
+    }
+  } else if (
+    (userInput.endHour && !userInput.endDate) ||
+    (!userInput.endHour &&
+      userInput.endDate &&
+      dataTableName !== lAttr &&
+      dataTableName !== rDat)
+  ) {
+    errors.push(needsEndDateTime)
+  }
+
+  return errors;
+}
+
+/**
+ * Checks if begin date and hour exist as options in user input and are nonempty
+ * for Formula table in MP
+ */
+const checkFormulaBeginDateAndHour = (userInput, errors, dataTableName) => {
+  const [beginDate, beginHour] = ["beginDate", "beginHour"]
+  const needsBeginDateTime = 'Must enter in both Begin Date and Time';
+
+  // skip validation if not Formula table
+  if (dataTableName !== 'Formula') return
+
+  if (userInput[beginDate] === null || userInput[beginHour] === null) {
+    errors.push(needsBeginDateTime)
+  }
+}

--- a/src/additional-functions/extract-user-input.test.js
+++ b/src/additional-functions/extract-user-input.test.js
@@ -1,4 +1,4 @@
-import { extractUserInput } from "./extract-user-input";
+import { extractUserInput, validateUserInput } from "./extract-user-input";
 import React from "react";
 import { Radio } from "@trussworks/react-uswds";
 import { render } from "@testing-library/react";
@@ -45,7 +45,7 @@ class Test extends React.Component {
   }
 }
 
-describe("extract user  functions", () => {
+describe("extract user functions", () => {
   it("should test with valid input", () => {
     const { container } = render(<Test />);
 
@@ -80,3 +80,30 @@ describe("extract user  functions", () => {
     expect(test).toBeDefined();
   });
 });
+
+describe("validateUserInput", () => {
+  const options = {
+    dataTableName: 'Formula',
+    lAttr: 'lAttr',
+    rDat: 'rDat'
+  }
+  test("given valid data then returns no errors", () => {
+    const validInput = {
+      beginDate: '03/22/2023',
+      beginHour: 0,
+      endDate: '03/23/2023',
+      endHour: 0
+    }
+    const errors = validateUserInput(validInput, options)
+    expect(errors).toHaveLength(0)
+  })
+
+  test("given invalid data then returns errors", () => {
+    const invalidInput = {
+      beginDate: null,
+      beginHour: 0
+    }
+    const errors = validateUserInput(invalidInput, options)
+    expect(errors).not.toHaveLength(0)
+  })
+})

--- a/src/components/datatablesContainer/DataTableAssert/DataTableAssert.js
+++ b/src/components/datatablesContainer/DataTableAssert/DataTableAssert.js
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from "react";
 import Modal from "../../Modal/Modal";
 import ModalDetails from "../../ModalDetails/ModalDetails";
 import { DataTableRender } from "../../DataTableRender/DataTableRender";
-import { extractUserInput } from "../../../additional-functions/extract-user-input";
+import { extractUserInput, validateUserInput } from "../../../additional-functions/extract-user-input";
 import { modalViewData } from "../../../additional-functions/create-modal-input-controls";
 import * as assertSelector from "../../../utils/selectors/assert";
 
@@ -17,10 +17,6 @@ import {
   changeGridCellAttributeValue,
   ensure508,
 } from "../../../additional-functions/ensure-508";
-import {
-  displayAppError,
-  needEndDate,
-} from "../../../additional-functions/app-error";
 import {
   assignFocusEventListeners,
   cleanupFocusEventListeners,
@@ -277,22 +273,11 @@ export const DataTableAssert = ({
       ".modalUserInput",
       radioNames ? radioNames : null
     );
-    if(dataTableName === "Formula"){
-      if(userInput.endHour === null || !userInput.endDate){
-        setErrorMsgs([needEndDate])
-        return;
-      }
+    const validationErrors = validateUserInput(userInput, { dataTableName, lAttr, rDat })
+    if (validationErrors.length > 0) {
+      setErrorMsgs(validationErrors)
+      return
     }
-    else if (
-      (userInput.endHour && !userInput.endDate) ||
-      (!userInput.endHour &&
-        userInput.endDate &&
-        dataTableName !== lAttr &&
-        dataTableName !== rDat)
-    ) {
-      setErrorMsgs([needEndDate]);
-      return;
-    } 
     try {
       const resp = await assertSelector.saveDataSwitch(userInput, dataTableName, locationSelectValue, urlParameters);
       if (resp.status === 200) {
@@ -316,22 +301,12 @@ export const DataTableAssert = ({
       ".modalUserInput",
       radioNames ? radioNames : null
     );
-    if(dataTableName === "Formula"){
-      if(userInput.endHour === null || !userInput.endDate){
-        setErrorMsgs([needEndDate])
-        return;
-      }
+    const validationErrors = validateUserInput(userInput, { dataTableName, lAttr, rDat })
+    if (validationErrors.length > 0) {
+      setErrorMsgs(validationErrors)
+      return
     }
-    else if (
-      (userInput.endHour && !userInput.endDate) ||
-      (!userInput.endHour &&
-        userInput.endDate &&
-        dataTableName !== lAttr &&
-        dataTableName !== rDat)
-    ) {
-      setErrorMsgs([needEndDate])
-      return;
-    }
+
     try {
       const resp = await assertSelector.createDataSwitch(userInput, dataTableName, locationSelectValue, urlParameters);
       if (resp.status === 201) {


### PR DESCRIPTION
Issue 1:
For MP Formula, a user is able to create a record without adding the Begin Date and Time which is not the expected behavior. The system should display an error message mandating the user to add the Begin Date and Time. This is also applicable to editing the record

Note: This issue is seen with Formula, Loads, WAFs Rectangular Duct, Span, System

Issue 2:
For MP Formula, when a user doesn't make a selection (Create/Edit) for the Begin Time (Leave it as 'Select a value'), then the system saves and displays it as 0 which is not the same as Null

Expected Behavior: Begin Time is a mandatory field and goes together with the Begin Date.

When a user doesn't make a selection for Begin Date and Time, then the system should display the applicable error message
When a user makes a selection for either Begin Date or Begin Time, then it should display the following message: Must enter in both Begin Date and Begin Time
Note: This issue is seen with Formula, Loads, WAFs Rectangular Duct, Span, System