### PR TITLE
fix issue where importMP passes error messages when there is no error

### DIFF
--- a/src/components/HeaderInfo/HeaderInfo.js
+++ b/src/components/HeaderInfo/HeaderInfo.js
@@ -49,6 +49,7 @@ import {
   displayReport,
   getPreviouslyFullSubmitedQuarter,
   getQuarter,
+  formatErrorResponse,
 } from "../../utils/functions";
 import { EmissionsImportTypeModalContent } from "./EmissionsImportTypeModalContent";
 import { ImportHistoricalDataModal } from "./ImportHistoricalDataModal";
@@ -683,7 +684,8 @@ export const HeaderInfo = ({
       .then((response) => {
         setIsLoading(true);
         if (!successResponses.includes(response.status)) {
-          setImportedFileErrorMsgs(response);
+          const errorMsgs = formatErrorResponse(response)
+          setImportedFileErrorMsgs(errorMsgs);
         }
       })
       .catch((err) => {

--- a/src/components/HeaderInfo/HeaderInfo.js
+++ b/src/components/HeaderInfo/HeaderInfo.js
@@ -59,7 +59,7 @@ import {
   setViewDataColumns,
   setViewTemplateSelectionAction,
 } from "../../store/actions/dynamicFacilityTab";
-import { handleError } from "../../utils/api/apiUtils";
+import { handleError, successResponses } from "../../utils/api/apiUtils";
 import {
   displayAppError,
   hideAppError,
@@ -682,7 +682,7 @@ export const HeaderInfo = ({
       .importMP(payload)
       .then((response) => {
         setIsLoading(true);
-        if (response) {
+        if (!successResponses.includes(response.status)) {
           setImportedFileErrorMsgs(response);
         }
       })

--- a/src/components/ImportModal/ImportModal.js
+++ b/src/components/ImportModal/ImportModal.js
@@ -23,7 +23,7 @@ const ImportModal = ({
   fileName,
   setHasFormatError,
   setHasInvalidJsonError,
-  importedFileErrorMsgs = [],
+  importedFileErrorMsgs,
   setImportedFile,
   workspaceSection,
 }) => {
@@ -32,8 +32,6 @@ const ImportModal = ({
   const [emSchema, setEmSchema] = useState([]);
   const [schemaErrors, setSchemaErrors] = useState([]);
   const [label, setLabel] = useState("");
-
-  importedFileErrorMsgs = Array.isArray(importedFileErrorMsgs) ? importedFileErrorMsgs : [importedFileErrorMsgs]
 
   useEffect(() => {
     switch (workspaceSection) {

--- a/src/components/QACertTestSummaryHeaderInfo/QACertTestSummaryHeaderInfo.js
+++ b/src/components/QACertTestSummaryHeaderInfo/QACertTestSummaryHeaderInfo.js
@@ -28,6 +28,8 @@ import {
 import { CreateOutlined, LockOpenSharp } from "@material-ui/icons";
 import * as mpApi from "../../utils/api/monitoringPlansApi";
 import { checkoutAPI } from "../../additional-functions/checkout";
+import { successResponses } from "../../utils/api/apiUtils";
+import { formatErrorResponse } from "../../utils/functions";
 
 export const QACertTestSummaryHeaderInfo = ({
   facility,
@@ -269,8 +271,9 @@ export const QACertTestSummaryHeaderInfo = ({
       .then((response) => {
         setShowImportModal(true)
         setUsePortBtn(true);
-        if (response) {
-          setImportedFileErrorMsgs(response);
+        if (!successResponses.includes(response.status)) {
+          const errorMsgs = formatErrorResponse(response)
+          setImportedFileErrorMsgs(errorMsgs);
         }
       })
       .catch((err) => {

--- a/src/utils/functions.js
+++ b/src/utils/functions.js
@@ -290,3 +290,13 @@ export const formatHourString = hour => {
   }
   return String(hour).padStart(2, '0');
 }
+
+/**
+ * Formats errored response into list of strings
+ * @param {*} errorResp 
+ * @returns 
+ */
+export const formatErrorResponse = errorResp => {
+  const errorMsgs = Array.isArray(errorResp) ? errorResp : [JSON.stringify(errorResp)]
+  return errorMsgs
+}


### PR DESCRIPTION
For importQA and importMP errored response is formatted to list of strings before being passed to importedFileErrorMsgs.