### PR TITLE
fix/4995-spinner-not-displaying

### DIFF
--- a/src/components/export/ExportTab/ExportTab.js
+++ b/src/components/export/ExportTab/ExportTab.js
@@ -67,6 +67,11 @@ export const ExportTab = ({
       },
       workspaceSection
     );
+
+    if(previewOptions && !dataTypesCopy[index].checked){
+      setPreviewOptions(undefined);
+    }
+      
   };
 
   const reportingPeriodSelectionHandler = (selectedObj) => {


### PR DESCRIPTION
Showing spinner when exporting from export section

Hiding the preview from export module unless QA is checked
