### PR TITLE
Fixed error with default waf

### DIFF
--- a/src/additional-functions/extract-user-input.js
+++ b/src/additional-functions/extract-user-input.js
@@ -54,7 +54,7 @@ export const extractUserInput = (payload, inputSelector, radios) => {
       continue;
     }
     if (item.value !== undefined) {
-      if (typeof item.value === "string" && (isNaN(item.value) || (item.value.length > 1 && item.value.charAt(0) === '0'))) {
+      if (typeof item.value === "string" && (isNaN(item.value) || (item.value.length > 1 && item.value.charAt(0) === '0' && item.value.charAt(1) != '.'))) {
         payload[item.name] =
           item.value.trim() === "" ? null : item.value.trim();
       }


### PR DESCRIPTION
Issue:
When creating or editing Rectangular Duct WAF's data record, the system displays a validation that won't get cleared up even when the data is corrected. Also, it displays a validation for Defaults in Rectangular Duct WAF's

Steps to Recreate:

Login to ECMPS
Access the MP Module, select and check out a Configuration (Dolet Hills Power Station (ORIS Code 51)
Select Rectangular Duct WAFs from the Sections dropdown
Click Create and enter all the information as needed
You will see that the system displays the following validations and these validations do not get cleared even after the data has been corrected: