### PR TITLE
Feature/4929 eval status hyperlink

### DIFF
--- a/src/components/HeaderInfo/HeaderInfo.js
+++ b/src/components/HeaderInfo/HeaderInfo.js
@@ -616,12 +616,16 @@ export const HeaderInfo = ({
     const alertStyle = `padding-1 usa-alert usa-alert--no-icon text-center ${evalStatusStyle(
       evalStatus
     )} margin-y-0`;
-
+    const params = {
+      reportCode: "MP_EVAL",
+      facilityId: orisCode,
+      monitorPlanId: selectedConfig.id
+    }
     const evalStatusHyperlink = (
       <div className={alertStyle}>
         <button
           className={"hyperlink-btn cursor-pointer"}
-          onClick={() => displayReport("MP_EVAL", orisCode, selectedConfig.id)}
+          onClick={() => displayReport(params)}
         >
           {evalStatusText(evalStatus)}
         </button>

--- a/src/components/QACertEventTabRender/QACertEventTabRender.js
+++ b/src/components/QACertEventTabRender/QACertEventTabRender.js
@@ -56,6 +56,7 @@ export const QACertEventTabRender = ({
           stackPipeId: locations[locationSelect[0]]["stackPipeId"],
           unitId: locations[locationSelect[0]]["unitId"],
         }}
+        orisCode={orisCode}
         locations={locations}
         selectedTestCode={selectedTestCode}
         isCheckedOut={checkoutState}

--- a/src/components/qaDatatablesContainer/QACertEventTestExmpDataTable/QACertEventTestExmpDataTable.js
+++ b/src/components/qaDatatablesContainer/QACertEventTestExmpDataTable/QACertEventTestExmpDataTable.js
@@ -48,6 +48,7 @@ const QACertEventTestExmpDataTable = ({
   isCheckedOut,
   sectionSelect,
   selectedLocation,
+  orisCode,
   locations,
 }) => {
   const [loading, setLoading] = useState(false);
@@ -332,9 +333,9 @@ const QACertEventTestExmpDataTable = ({
   const data = useMemo(() => {
     switch (sectionSelect[1]) {
       case "QA Certification Event":
-        return mapQaCertEventsDataToRows(qaTestSummary);
+        return mapQaCertEventsDataToRows(qaTestSummary, orisCode);
       case "Test Extension Exemption":
-        return mapQaExtensionsExemptionsDataToRows(qaTestSummary);
+        return mapQaExtensionsExemptionsDataToRows(qaTestSummary, orisCode);
       default:
         return [];
     }
@@ -417,9 +418,9 @@ const QACertEventTestExmpDataTable = ({
 
     switch (sectionSelect[1]) {
       case "QA Certification Event":
-        updatedData = mapQaCertEventsDataToRows(data ? data : []);
+        updatedData = mapQaCertEventsDataToRows(data ? data : [], orisCode);
       case "Test Exemptions and Exeptions":
-        updatedData = mapQaExtensionsExemptionsDataToRows(data ? data : []);
+        updatedData = mapQaExtensionsExemptionsDataToRows(data ? data : [], orisCode);
       default:
         break;
     }

--- a/src/components/qaDatatablesContainer/QACertEventTestExmpDataTable/QACertEventTestExmpDataTable.test.js
+++ b/src/components/qaDatatablesContainer/QACertEventTestExmpDataTable/QACertEventTestExmpDataTable.test.js
@@ -26,6 +26,7 @@ const renderComponent = (props) => {
     selectedTestCode={null}
     isCheckedOut={props.isCheckedOut}
     sectionSelect={props.sectionSelect}
+    orisCode={props.orisCode}
     selectedLocation={props.selectedLocation}
     locations={[]}
     />

--- a/src/utils/selectors/QACert/TestSummary.js
+++ b/src/utils/selectors/QACert/TestSummary.js
@@ -64,6 +64,7 @@ export const getTestSummary = (data, colTitles, orisCode) => {
             colValue = curData.unitId ?? curData.stackPipeId;
             break;
           case "Eval Status":
+            console.log(id, curData)
             colValue = evalStatusContent(curData.evalStatusCode, orisCode, id);
             break;
           default:
@@ -624,7 +625,7 @@ export const mapHgInjectionDataToRows = (data) => {
   return records;
 };
 
-export const mapQaCertEventsDataToRows = (data) => {
+export const mapQaCertEventsDataToRows = (data, orisCode) => {
   const records = [];
   for (const el of data) {
     const row = {
@@ -637,14 +638,14 @@ export const mapQaCertEventsDataToRows = (data) => {
       col6: el.requiredTestCode,
       col7: formatDateTime(el.conditionalBeginDate, el.conditionalBeginHour),
       col8: formatDateTime(el.completionTestDate, el.completionTestHour),
-      col9: evalStatusContent(el.evalStatusCode),
+      col9: evalStatusContent(el.evalStatusCode, orisCode, el.id),
     };
     records.push(row);
   }
   return records;
 };
 
-export const mapQaExtensionsExemptionsDataToRows = (data) => {
+export const mapQaExtensionsExemptionsDataToRows = (data, orisCode) => {
   const records = [];
 
   data.forEach((el) => {
@@ -666,7 +667,7 @@ export const mapQaExtensionsExemptionsDataToRows = (data) => {
       col7: el.spanScaleCode,
       col8: el.fuelCode,
       col9: el.extensionOrExemptionCode,
-      col10: evalStatusContent(el.evalStatusCode),
+      col10: evalStatusContent(el.evalStatusCode, orisCode, el.id),
     });
   });
 


### PR DESCRIPTION
As an ECMPS user, I want the ability to access the QA Evaluation Report for each Test record so that I can review the errors and make updates to data as needed

Acceptance Criteria:

Given I am logged into ECMPS and I am in the QA Module (Test Data/Cert Events and TEE)
And I have a Test Data record that has been Evaluated
When I click on the Evaluation Status of Passed/Critical Errors/Informational Message
Then it opens the QA Evaluation Report on the UI

Note: Review Mass Evaluations screen for the Reports link