### PR TITLE
Feature/4929 eval status hyperlink

### DIFF
--- a/src/additional-functions/evaluate-configs.js
+++ b/src/additional-functions/evaluate-configs.js
@@ -64,5 +64,5 @@ const evalStatusStyle = (status) => {
   };
   
   const showHyperLink = (status) => {
-    return status === "PASS" || status === "INFO" || status === "ERR" || status === "EVAL";
+    return status === "PASS" || status === "INFO" || status === "ERR";
   };

--- a/src/utils/selectors/QACert/TestSummary.js
+++ b/src/utils/selectors/QACert/TestSummary.js
@@ -64,7 +64,6 @@ export const getTestSummary = (data, colTitles, orisCode) => {
             colValue = curData.unitId ?? curData.stackPipeId;
             break;
           case "Eval Status":
-            console.log(id, curData)
             colValue = evalStatusContent(curData.evalStatusCode, orisCode, id);
             break;
           default:


### PR DESCRIPTION
As an ECMPS user, I want the ability to access the QA Evaluation Report for each Test record so that I can review the errors and make updates to data as needed

Acceptance Criteria:

Given I am logged into ECMPS and I am in the QA Module (Test Data/Cert Events and TEE)
And I have a Test Data record that has been Evaluated
When I click on the Evaluation Status of Passed/Critical Errors/Informational Message
Then it opens the QA Evaluation Report on the UI

Note: Review Mass Evaluations screen for the Reports link