### PR TITLE
Fixed error with monSysId, componentId, and testNumber formatting

### DIFF
--- a/src/additional-functions/extract-user-input.js
+++ b/src/additional-functions/extract-user-input.js
@@ -66,7 +66,7 @@ export const extractUserInput = (payload, inputSelector, radios) => {
       }
       // is a number
       else if (typeof item.value === "string" && !isNaN(item.value)) {
-        if (payload[item.name] === "string") {
+        if (payload[item.name] === "string" || (typeof payload[item.name]) === "string") {
           payload[item.name] =
             item.value.trim() === "" ? null : item.value.trim();
         }

--- a/src/components/qaDatatablesContainer/QATestSummaryDataTable/QATestSummaryDataTable.js
+++ b/src/components/qaDatatablesContainer/QATestSummaryDataTable/QATestSummaryDataTable.js
@@ -483,9 +483,10 @@ const QATestSummaryDataTable = ({
     stackPipeId: null,
     unitId: null,
     testTypeCode: null,
-    componentID: null,
+    componentID: "string",
+    monitoringSystemID: "string",
     spanScaleCode: null,
-    testNumber: null,
+    testNumber: "string",
     testReasonCode: null,
     testResultCode: null,
     beginDate: null,
@@ -512,6 +513,9 @@ const QATestSummaryDataTable = ({
       .then((res) => {
         if (Object.prototype.toString.call(res) === '[object Array]') {
           alert(res[0]);
+          uiControls.componentID = "string";
+          uiControls.monitoringSystemID = "string";
+          uiControls.testNumber = "string";
         } else {
           setUpdateTable(true);
           executeOnClose();
@@ -554,6 +558,9 @@ const QATestSummaryDataTable = ({
       .then((res) => {
         if (Object.prototype.toString.call(res) === '[object Array]') {
           alert(res[0]);
+          uiControls.componentID = "string";
+          uiControls.monitoringSystemID = "string";
+          uiControls.testNumber = "string";
         } else {
           setCreatedId(res.data.id);
           setUpdateTable(true);


### PR DESCRIPTION
Fixed error with monSysId, componentId, and testNumber formatting where all 3 would be sent as numbers instead of as strings