### PR TITLE
getApiUrl for exportQA

### DIFF
--- a/src/utils/api/qaCertificationsAPI.js
+++ b/src/utils/api/qaCertificationsAPI.js
@@ -210,12 +210,8 @@ export const exportQA = async (
     isHistoricalImport: Boolean,
   }
 ) => {
-  let url = getApiUrl()
-  if (options.isOfficial) {
-    url = `${url}/export?facilityId=${facilityId}`
-  } else {
-    url = `${url}/export?facilityId=${facilityId}`
-  }
+  const path = `/export?facilityId=${facilityId}`
+  let url = getApiUrl(path)
 
   if (options.isHistoricalImport) {
     url = `${url}&qaTestExtensionExemptionIds=null&qaCertificationEventIds=null`;

--- a/src/utils/api/qaCertificationsAPI.js
+++ b/src/utils/api/qaCertificationsAPI.js
@@ -4,7 +4,7 @@ import { handleResponse, handleError, handleImportError } from "./apiUtils";
 import config from "../../config";
 import { secureAxios } from "./easeyAuthApi";
 
-const getApiUrl = (path) => {
+const getApiUrl = (path = '') => {
   let url = config.services.qaCertification.uri;
 
   if (window.location.href.includes("/workspace")) {
@@ -210,12 +210,11 @@ export const exportQA = async (
     isHistoricalImport: Boolean,
   }
 ) => {
-  let url;
-
+  let url = getApiUrl()
   if (options.isOfficial) {
-    url = `${config.services.qaCertification.uri}/export?facilityId=${facilityId}`;
+    url = `${url}/export?facilityId=${facilityId}`
   } else {
-    url = getApiUrl(`/export?facilityId=${facilityId}`);
+    url = `${url}/export?facilityId=${facilityId}`
   }
 
   if (options.isHistoricalImport) {


### PR DESCRIPTION
When you are logged in to ECMPS, access the Export, and select QA & Certification option to Preview, then it is calling the official/non-workspace endpoint to retrieve export data instead of the workspace endpoint.