### PR TITLE
Feature/5113 mon sys id app e gas

### DIFF
--- a/src/additional-functions/qa-dataTable-props.js
+++ b/src/additional-functions/qa-dataTable-props.js
@@ -507,9 +507,17 @@ export const qaAppendixECorrelationSummaryHeatInputGasProps = (selectedRow) => {
       gasHeatInput: 0,
       monitoringSystemID: "string",
     },
-    dropdownArray: [],
-    columnNames: ["Gas GCV", "Gas Volume", "Gas Heat Input"],
+    dropdownArray: [
+      "monitoringSystemID",
+    ],
+    columnNames: [
+      "Monitoring System ID",
+      "Gas GCV", 
+      "Gas Volume", 
+      "Gas Heat Input",
+    ],
     controlInputs: {
+      monitoringSystemID: ["Monitoring System ID", "dropdown", "", ""],
       gasGCV: ["Gas GCV", "input", "", ""],
       gasVolume: ["Gas Volume", "input", "", ""],
       gasHeatInput: ["Gas Heat Input", "input", "", ""],

--- a/src/components/qaDatatablesContainer/QAExpandableRowsRender/QAExpandableRowsRender.js
+++ b/src/components/qaDatatablesContainer/QAExpandableRowsRender/QAExpandableRowsRender.js
@@ -579,6 +579,32 @@ const QAExpandableRowsRender = ({
           })
           .catch((error) => console.log(error));
         break;
+      case "Appendix E Correlation Heat Input from Gas":
+        allPromises.push(dmApi.getAllMonitoringSystemIDCodes(extraIDs[0]));
+        Promise.all(allPromises)
+          .then((responses) => {
+            responses.forEach((curResp, i) => {
+              let codeLabel;
+              let descriptionLabel;
+              switch (i) {
+                case 0:
+                  codeLabel = "monitoringSystemIDCode";
+                  descriptionLabel = "monitoringSystemIDDescription";
+                  break;
+                default:
+                  break;
+              }
+              dropdowns[dropdownArray[i]] = curResp.data.map((d) => {
+                return { code: d[codeLabel], name: d[descriptionLabel] };
+              });
+            });
+            for (const options of Object.values(dropdowns)) {
+              options.unshift({ code: "", name: "-- Select a value --" });
+            }
+            setMdmData(dropdowns);
+          })
+          .catch((error) => console.log(error));
+        break;
       case "Appendix E Correlation Heat Input from Oil":
         allPromises.push(dmApi.getAllMonitoringSystemIDCodes(extraIDs[0]));
         allPromises.push(dmApi.getAllUnitsOfMeasureCodes());

--- a/src/utils/api/qaCertificationsAPI.js
+++ b/src/utils/api/qaCertificationsAPI.js
@@ -1247,7 +1247,6 @@ export const createAppendixEHeatInputGas = async (
   payload
 ) => {
   const testSummary = await getQATestSummaryByID(locId, testSumId);
-  payload.monitoringSystemID = testSummary.data.monitoringSystemID;
   const path = `/locations/${locId}/test-summary/${testSumId}/appendix-e-correlation-test-summaries/${appECorrTestSumId}/appendix-e-correlation-test-runs/${appECorrTestRunId}/appendix-e-heat-input-from-gases`;
   const url = getApiUrl(path);
   try {

--- a/src/utils/selectors/QACert/TestSummary.js
+++ b/src/utils/selectors/QACert/TestSummary.js
@@ -341,9 +341,10 @@ export const mapAppendixECorrHeatInputGasToRows = (data) => {
   for (const el of data) {
     const row = {
       id: el.id,
-      col1: el.gasGCV === 0 ? "0" : el.gasGCV,
-      col2: el.gasVolume === 0 ? "0" : el.gasVolume,
-      col3: el.gasHeatInput === 0 ? "0" : el.gasHeatInput,
+      col1: el.monitoringSystemID,
+      col2: el.gasGCV === 0 ? "0" : el.gasGCV,
+      col3: el.gasVolume === 0 ? "0" : el.gasVolume,
+      col4: el.gasHeatInput === 0 ? "0" : el.gasHeatInput,
     };
     records.push(row);
   }

--- a/src/utils/selectors/QACert/TestSummary.test.js
+++ b/src/utils/selectors/QACert/TestSummary.test.js
@@ -493,6 +493,27 @@ describe("testing TestSummary data selectors", () => {
     ];
     expect(fs.mapAppendixECorrHeatInputOilToRows(data)).toEqual(records);
   });
+  test("mapAppendixECorrHeatInputGasToRows", () => {
+    const data = [
+      {
+        id: "0000120",
+        monitoringSystemID: '100',
+        gasGCV: 1,
+        gasVolume: 1,
+        gasHeatInput: 1,
+      },
+    ];
+    const records = [
+      {
+        id: '0000120',
+        col1: '100',
+        col2: 1,
+        col3: 1,
+        col4: 1,
+      },
+    ];
+    expect(fs.mapAppendixECorrHeatInputGasToRows(data)).toEqual(records);
+  });
   test("mapFuelFlowmeterAccuracyDataToRows", () => {
     const data = [
       {


### PR DESCRIPTION
Currently, App E Correlation Heat Input from Gas doesn't have the Mon Sys ID field. Add the field similar to App E Correlation Heat Input from Oil