### PR TITLE
5150 - Remove 'Revert' Button From Emmissions

### DIFF
--- a/src/components/HeaderInfo/HeaderInfo.js
+++ b/src/components/HeaderInfo/HeaderInfo.js
@@ -1100,7 +1100,7 @@ export const HeaderInfo = ({
                       <CreateOutlined color="primary" /> {"Check Out"}
                     </Button>
                   ) : null}
-                  {showRevert(evalStatus) && (
+                  {workspaceSection === MONITORING_PLAN_STORE_NAME && showRevert(evalStatus) && (
                     <Button
                       type="button"
                       id="showRevertModal"


### PR DESCRIPTION
Removes the 'Revert to Official Record' from the Emissions module header 