### PR TITLE
Fixed error where opening configurations from multiple locations woul…

### DIFF
--- a/src/components/DynamicTabs/DynamicTabs.js
+++ b/src/components/DynamicTabs/DynamicTabs.js
@@ -40,7 +40,7 @@ export const DynamicTabs = ({
             orisCode: t.orisCode,
             checkout: t.checkout,
             name: t.title,
-            location: [0, t.selectedConfig.locations[0].id],
+            location: [0, t.selectedConfig.locations[0].id ?? null],
             section: [4, "Methods"], // watch out for this outside MP
             selectedConfig: t.selectedConfig,
             facId: t.selectedConfig.locations[0].facId,

--- a/src/components/datatablesContainer/DataTableConfigurations/DataTableConfigurations.js
+++ b/src/components/datatablesContainer/DataTableConfigurations/DataTableConfigurations.js
@@ -33,10 +33,14 @@ export const DataTableConfigurations = ({
   const findSelectedConfig = (configID) => {
     let val = 0;
     if (selectedMP.length > 0) {
-      for (const x of selectedMP[1]) {
-        if (x.id === configID) {
-          val = x;
-          break;
+      for (const currentMP of selectedMP){
+        if(currentMP !== undefined){
+          for (const x of currentMP[1]) {
+            if (x.id === configID) {
+              val = x;
+              break;
+            }
+          }
         }
       }
     }
@@ -130,7 +134,7 @@ export const DataTableConfigurations = ({
   }, []);
 
   useEffect(() => {
-    setSelectedMp(monitoringPlans[monitoringPlans.length - 1]);
+    setSelectedMp([...selectedMP, monitoringPlans[monitoringPlans.length - 1]])
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [monitoringPlans.length]);

--- a/src/utils/selectors/monitoringPlanDefaults.js
+++ b/src/utils/selectors/monitoringPlanDefaults.js
@@ -13,7 +13,7 @@ export const getMonitoringPlansDefaultsTableRecords = (totalData) => {
       col5: el.operatingConditionCode,
       col6: el.defaultSourceCode,
       col7: formatDateTime(el.beginDate, el.beginHour),
-      col8: formatDateTime(el.beginDate, el.beginHour),
+      col8: formatDateTime(el.endDate, el.endHour),
       col9: el.id,
     });
   });

--- a/src/utils/selectors/monitoringPlanDefaults.test.js
+++ b/src/utils/selectors/monitoringPlanDefaults.test.js
@@ -88,7 +88,7 @@ describe("testing monitoring plan data selectors", () => {
         col5: "A",
         col6: "DATA",
         col7: "2001-02-26 16:00",
-        col8: "2001-02-26 16:00",
+        col8: "",
         col9: "CAMD-E86CD02DFD9F417D8F8CA029A11DEE0B",
       },
       {
@@ -99,7 +99,7 @@ describe("testing monitoring plan data selectors", () => {
         col5: "A",
         col6: "DATA",
         col7: "",
-        col8: "",
+        col8: "2001-02-26 16:00",
         col9: "CAMD-E86CD02DFD9F417D8F8CA029A11DEE0B",
       },
     ];


### PR DESCRIPTION
Expanding multiple location configurations and selecting a configuration from the most recently expanded location would cause a blank screen

Also fixed bug where monitor defaults end Date had the value of the begin Date