### PR TITLE
fix/5212 - Keep Selected Report Periods on Emissions Checkout/In

### DIFF
--- a/src/components/HeaderInfo/HeaderInfo.js
+++ b/src/components/HeaderInfo/HeaderInfo.js
@@ -255,6 +255,7 @@ export const HeaderInfo = ({
     if (currentTab === undefined || currentTab?.reportingPeriods) {
       return;
     }
+    
     let selectedRptPeriods;
     if (inWorkspace) {
       selectedRptPeriods = reportingPeriods

--- a/src/components/HeaderInfo/HeaderInfo.js
+++ b/src/components/HeaderInfo/HeaderInfo.js
@@ -255,7 +255,6 @@ export const HeaderInfo = ({
     if (currentTab === undefined || currentTab?.reportingPeriods) {
       return;
     }
-
     let selectedRptPeriods;
     if (inWorkspace) {
       selectedRptPeriods = reportingPeriods
@@ -783,6 +782,7 @@ export const HeaderInfo = ({
     //    - DELETE endpoint if direction is FALSE (removing record from checkouts table)
     checkoutAPI(direction, configID, selectedConfig.id, setCheckout)
       .then(() => {
+        handleSelectReportingPeriod();
         setCheckedOutByUser(direction);
         setLockedFacility(direction);
         // setCheckoutState(direction);


### PR DESCRIPTION
When the selected Reporting Periods was changed and then the Checkout or Check Back In button was clicked (without first clicking the "Apply Filters" Button), the Reporting Periods combo select box was reverting to the previous selections.  This change locks in the selections that are made before Check Out/In is clicked so the re-render doesn't restore the old selections.