### PR TITLE
fix/5416 - facilityId filter in the EM Submission Access GET endpoint

### DIFF
--- a/src/utils/api/adminManagementApi.js
+++ b/src/utils/api/adminManagementApi.js
@@ -20,7 +20,7 @@ export const getEmSubmissionRecords = async (
   return secureAxios({
     url: url,
     params: {
-      facilityId: orisCode,
+      orisCode,
       monitorPlanId,
       year,
       quarter,


### PR DESCRIPTION
Changes API Query param from facilityId to orisCode for GET /camd-services/admin/em-submission-access