### PR TITLE
fix/5533 - Save Unit Control Radio Values as Strings

### DIFF
--- a/src/utils/api/monitoringPlansApi.js
+++ b/src/utils/api/monitoringPlansApi.js
@@ -713,6 +713,11 @@ export const getMonitoringPlansUnitControlRecords = async (
 };
 
 export const saveUnitControl = async (payload, urlParameters) => {
+  // These two radio fields must be converted to
+  // STRING values of "1" (Yes) or "0" (No)
+  payload.originalCode = payload.originalCode?.toString();
+  payload.seasonalControlsIndicator = payload.seasonalControlsIndicator?.toString();
+
   const url = getApiUrl(
     `/locations/${urlParameters["locId"]}/units/${urlParameters["unitRecordId"]}/unit-controls/${payload["id"]}`
   );


### PR DESCRIPTION
Fixed saving of two radio fields for UnitControl (originalCode and seasonalControlsIndicator) that were being sent as number values (1 = Yes, 0 = no) when they should be the strings "1" and "0".  