### PR TITLE
fix/5580 - Save Unit Control 'Original Code' as String

### DIFF
--- a/src/utils/api/monitoringPlansApi.js
+++ b/src/utils/api/monitoringPlansApi.js
@@ -742,6 +742,11 @@ export const createUnitControl = async (payload, urlParameters) => {
   // *** remove attributes not needed by the API
   delete payload["id"];
 
+  // These two radio fields must be converted to
+  // STRING values of "1" (Yes) or "0" (No)
+  payload.originalCode = payload.originalCode?.toString();
+  payload.seasonalControlsIndicator = payload.seasonalControlsIndicator?.toString();
+
   try {
     return handleResponse(
       await secureAxios({


### PR DESCRIPTION
To match API Spec, converts numeric 0/1 for Original Code (radio value) to "0" or "1" when creating a new Unit Control.  This fix was already made for Unit Control updates.