### PR TITLE
fix / 5747 Show Import from Historical Error only in Modal

### DIFF
--- a/src/components/HeaderInfo/ImportHistoricalDataModal.js
+++ b/src/components/HeaderInfo/ImportHistoricalDataModal.js
@@ -56,8 +56,7 @@ export const ImportHistoricalDataModal = ({
       setImportedFileErrorMsgs([]);
       portCallback(selectedYear, selectedQuarter)
     } catch (error) {
-      console.log(JSON.stringify(error))
-      const errorMsgs = error?.data?.message ?? ['There was an error importing historical data']
+      const errorMsgs = error?.response?.data?.message ?? ['There was an error importing historical data']
       setImportedFileErrorMsgs(errorMsgs)
     } finally {
       setIsLoading(false);

--- a/src/utils/api/apiUtils.js
+++ b/src/utils/api/apiUtils.js
@@ -43,11 +43,6 @@ export function handleError(error) {
   if (errorMessage !== "") {
     displayAppError(errorMessage);
   }
-
-  // sonarcloud doesnt want to return anything
-  // if (error.response) {
-  //   return error.response.data.message;
-  // }
 }
 
 export function handleImportError(error) {

--- a/src/utils/api/emissionsApi.js
+++ b/src/utils/api/emissionsApi.js
@@ -51,16 +51,12 @@ export const exportEmissionsData = async (
     reportedValuesOnly: true,
   });
 
-  try {
-    const response = await secureAxios({
-      url: `${url.toString()}?${searchParams.toString()}`,
-      method: "GET",
-    });
-    return handleResponse(response);
-  } catch (error) {
-    handleError(error);
-    return error.response;
-  }
+  const response = await secureAxios({
+    url: `${url.toString()}?${searchParams.toString()}`,
+    method: "GET",
+   });
+
+  return handleResponse(response);
 };
 
 export const exportEmissionsDataDownload = async (
@@ -71,15 +67,21 @@ export const exportEmissionsDataDownload = async (
   isWorkspace = false
 ) => {
   const fileName = `Emissions | Export - ${facility} - ${year} - Q${quarter}.json`;
-  const response = await exportEmissionsData(
-    monitorPlanId,
-    year,
-    quarter,
-    isWorkspace
-  );
 
-  if (response.status === 200)
-    download(JSON.stringify(response.data, null, "\t"), fileName);
+  try {
+    const response = await exportEmissionsData(
+        monitorPlanId,
+        year,
+        quarter,
+        isWorkspace
+    );
+
+    if (response.status === 200)
+      download(JSON.stringify(response.data, null, "\t"), fileName);
+
+  } catch(error) {
+    handleError(error);
+  }
 };
 
 export const getEmissionViewData = async (


### PR DESCRIPTION
Errors encountered from the Import-From-Historical modal were being displayed in both the modal and the main browser page. This change limits the message to just showing in the modal.