### PR TITLE
Call Workspace Export When Logged In

### DIFF
--- a/src/components/export/ExportTab/ExportTab.js
+++ b/src/components/export/ExportTab/ExportTab.js
@@ -161,7 +161,7 @@ export const ExportTab = ({
       selectedStacks,
       null,
       null,
-      { isOfficial: getUser() !== null, isHistoricalImport: false },
+      { isOfficial: !getUser(), isHistoricalImport: false },
       dataTypes[1].selectedRows.current.map((d) => d.testSumId),
       dataTypes[2].selectedRows.current.map((d) => d.qaCertEventIdentifier),
       dataTypes[3].selectedRows.current.map(


### PR DESCRIPTION
Before this fix, when a user was logged in and tried to Export QA/Test Data from the Export & Report tab, the OFFICIAL export api endpoint was being called instead of the WORKSPACE endpoint.
