### PR TITLE
Feature/5894-Add-Message-For-Old-And/or-Invalid-Evaluation-Reports

### DIFF
--- a/src/additional-functions/evaluate-configs.js
+++ b/src/additional-functions/evaluate-configs.js
@@ -49,7 +49,7 @@ const evalStatusStyle = (status) => {
       <div className={alertStyle}>
         <button
           className={"hyperlink-btn cursor-pointer"}
-          onClick={() => displayReport(params)}
+          onClick={() => displayReport(params, status)}
         >
           {evalStatusText(status)}
         </button>

--- a/src/additional-functions/evaluate-configs.js
+++ b/src/additional-functions/evaluate-configs.js
@@ -49,7 +49,7 @@ const evalStatusStyle = (status) => {
       <div className={alertStyle}>
         <button
           className={"hyperlink-btn cursor-pointer"}
-          onClick={() => displayReport(params, status)}
+          onClick={() => displayReport(params)}
         >
           {evalStatusText(status)}
         </button>

--- a/src/components/EvaluateAndSubmit/CategoryTable/CategoryTable.js
+++ b/src/components/EvaluateAndSubmit/CategoryTable/CategoryTable.js
@@ -2,7 +2,7 @@ import React, { useState, useCallback } from "react";
 import SelectableDataTable from "../SelectableDataTable/SelectableDataTable";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faChevronDown, faChevronUp } from "@fortawesome/free-solid-svg-icons";
-import { addEvalStatusCell } from "../../../utils/functions";
+import { addEvalStatusCell, storeEvalStatusInLocalStorage } from "../../../utils/functions";
 import { Button } from "@trussworks/react-uswds";
 import { Preloader } from "@us-epa-camd/easey-design-system";
 import { LockSharp } from "@material-ui/icons";
@@ -73,6 +73,9 @@ export const CategoryTable = ({
       `/workspace/reports?reportCode=${reportCode}&facilityId=${row.orisCode}` +
       additionalParams;
 
+    //set redux state with row info
+    // localStorage.setItem("reportRow", JSON.stringify(row));
+    storeEvalStatusInLocalStorage(row.evalStatusCode);
     window.open(url, reportTitle, reportWindowParams); //eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/components/EvaluateAndSubmit/CategoryTable/CategoryTable.js
+++ b/src/components/EvaluateAndSubmit/CategoryTable/CategoryTable.js
@@ -2,7 +2,11 @@ import React, { useState, useCallback } from "react";
 import SelectableDataTable from "../SelectableDataTable/SelectableDataTable";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faChevronDown, faChevronUp } from "@fortawesome/free-solid-svg-icons";
-import { addEvalStatusCell, storeEvalStatusInLocalStorage } from "../../../utils/functions";
+import {
+  addEvalStatusCell,
+  getYearQuarterParams,
+  isoToYearQuarter,
+} from "../../../utils/functions";
 import { Button } from "@trussworks/react-uswds";
 import { Preloader } from "@us-epa-camd/easey-design-system";
 import { LockSharp } from "@material-ui/icons";
@@ -69,13 +73,13 @@ export const CategoryTable = ({
       }&quarter=${yearQuarter[1].charAt(1)}`;
     }
 
+    const yearQuarterParams = getYearQuarterParams(row);
     url =
       `/workspace/reports?reportCode=${reportCode}&facilityId=${row.orisCode}` +
-      additionalParams;
+      additionalParams +
+      yearQuarterParams;
 
-    //set redux state with row info
     // localStorage.setItem("reportRow", JSON.stringify(row));
-    storeEvalStatusInLocalStorage(row.evalStatusCode);
     window.open(url, reportTitle, reportWindowParams); //eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/components/HeaderInfo/HeaderInfo.js
+++ b/src/components/HeaderInfo/HeaderInfo.js
@@ -768,7 +768,7 @@ export const HeaderInfo = ({
       <div className={alertStyle}>
         <button
           className={"hyperlink-btn cursor-pointer"}
-          onClick={() => displayReport(params, evalStatus)}
+          onClick={() => displayReport(params)}
         >
           {evalStatusDescription}
         </button>

--- a/src/components/HeaderInfo/HeaderInfo.js
+++ b/src/components/HeaderInfo/HeaderInfo.js
@@ -768,7 +768,7 @@ export const HeaderInfo = ({
       <div className={alertStyle}>
         <button
           className={"hyperlink-btn cursor-pointer"}
-          onClick={() => displayReport(params)}
+          onClick={() => displayReport(params, evalStatus)}
         >
           {evalStatusDescription}
         </button>

--- a/src/components/ReportGenerator/Report/Report.js
+++ b/src/components/ReportGenerator/Report/Report.js
@@ -6,6 +6,9 @@ import PropertyTableTemplate from "../PropertyTableTemplate/PropertyTableTemplat
 import config from "../../../config";
 import { downloadReport } from "../../../utils/api/camdServices";
 import { handleError } from "../../../utils/api/apiUtils";
+import { getEvalResultMessage } from "../../../utils/functions";
+import { getQACertEventReviewSubmit, getQATeeReviewSubmit, getQATestSummaryReviewSubmit } from "../../../utils/api/qaCertificationsAPI";
+import { getMonitoringPlans } from "../../../utils/api/monitoringPlansApi";
 
 export const Report = ({ reportData, dataLoaded, paramsObject }) => {
   const displayCloseButton = useState(true);
@@ -126,6 +129,30 @@ export const Report = ({ reportData, dataLoaded, paramsObject }) => {
       })
     );
   });
+  
+
+  const tableRowApi = {
+    "teeId" : getQATeeReviewSubmit,
+    "monitorPlanId": getMonitoringPlans,
+    "qceId" : getQACertEventReviewSubmit,
+    "testSumId": getQATestSummaryReviewSubmit,
+  }
+
+  const paramsArray = paramsObject.current
+  const orisCode = paramsArray[1][1]
+  , id = paramsArray[2][1], type = paramsArray[2][0], api = tableRowApi[type];
+  const getEvalStatus = async() => {
+    console.log({orisCode, type, api});
+    const response = await api([orisCode], [id])
+     console.log(response);
+   }
+   getEvalStatus()
+  const evalStatus = localStorage.getItem("evalStatus")? JSON.parse(localStorage.getItem("evalStatus")) : null;
+  const evalResultMessage = getEvalResultMessage(
+    reportData,
+    paramsObject,
+    evalStatus
+  );
 
   return (
     <>
@@ -199,6 +226,15 @@ export const Report = ({ reportData, dataLoaded, paramsObject }) => {
                 );
               }
             })}
+
+            {evalResultMessage && (
+              <div>
+                <h3 className="subheader-wrapper bg-epa-blue-base text-white text-normal padding-left-1 padding-y-2px">
+                  Evaluation Results
+                </h3>
+                <div>{evalResultMessage}</div>
+              </div>
+            )}
 
             <div className="position-fixed bottom-0 right-0 width-full do-not-print">
               <AppVersion

--- a/src/components/ReportGenerator/ReportGenerator.js
+++ b/src/components/ReportGenerator/ReportGenerator.js
@@ -35,7 +35,7 @@ export const ReportGenerator = ({ user, requireAuth = false }) => {
     }
   }, [requireAuth, user, dataLoaded, search]);
 
-  if (error) {
+  if (error || (dataLoaded && !reportData?.details.length)) {
     return <ErrorMessage error={error} />;
   }
 
@@ -94,7 +94,8 @@ export const ErrorMessage = ({ error }) => (
       </div>
       <div className="padding-x-5">
         <h1 className="text-bold">
-          An error occurred while generating the report
+          An error has occurred therefore a report cannot be generated at this
+          time. Please check back later or contact support.
         </h1>
         <p>{error}</p>
       </div>

--- a/src/config.js
+++ b/src/config.js
@@ -2,7 +2,7 @@ import {
   getConfigValue,
   getConfigValueNumber,
   getConfigValueBoolean,
-} from "./utils/functions";
+} from "./utils/configFunctions";
 
 export const oneSecond = 1000;
 export const fiveSeconds = 5000;

--- a/src/utils/functions.js
+++ b/src/utils/functions.js
@@ -185,9 +185,9 @@ export const formatReportUrl = (params, service) => {
   return url;
 };
 
-export const displayReport = (params) => {
+export const displayReport = (params, evalStatus) => {
   const url = `/workspace/reports?reportCode=MP_EVAL&facilityId=${params.facilityId}&monitorPlanId=${params.monitorPlanId}`;
-
+  storeEvalStatusInLocalStorage(evalStatus)
   window.open(url, "Monitoring Plan Evaluation Report", reportWindowParams); //eslint-disable-next-line react-hooks/exhaustive-deps
 };
 
@@ -232,6 +232,23 @@ export const addEvalStatusCell = (columns, callback) =>
     return col;
   });
 
+export const storeEvalStatusInLocalStorage = (evalStatus) => localStorage.setItem("evalStatus", JSON.stringify(evalStatus));
+export const getEvalResultMessage = (reportData, paramsObject, evalStatus) => {
+  if (evalStatus === null) return;
+  const reportCode = paramsObject.current[0][1];
+  let message;
+  if (reportCode.includes("EVAL")) {
+    const isPassing = evalStatus === "PASS";
+    console.log({evalStatus});
+    if (isPassing) {
+      message = "Evaluation has passed without errors";
+    } else if (reportData.details.length < 2) {
+      message =
+        "Evaluation is old or expired and error data is no longer available";
+    }
+    return message;
+  }
+};
 // Returns the previously fully submitted quarter (reporting period).
 // For the first month of every quarter, the previusly submitted reporting period is actually two quarters ago.
 // For every month in between it is the previous quarter.

--- a/src/utils/functions.js
+++ b/src/utils/functions.js
@@ -142,7 +142,7 @@ export const formatReportUrl = (params, service) => {
   return url;
 };
 
-export const displayReport = (params, evalStatus) => {
+export const displayReport = (params) => {
   const url = `/workspace/reports?reportCode=MP_EVAL&facilityId=${params.facilityId}&monitorPlanId=${params.monitorPlanId}`;
   window.open(url, "Monitoring Plan Evaluation Report", reportWindowParams); //eslint-disable-next-line react-hooks/exhaustive-deps
 };

--- a/src/utils/functions.test.js
+++ b/src/utils/functions.test.js
@@ -1,9 +1,6 @@
 import _ from "lodash";
 import {
   formatDate,
-  getConfigValue,
-  getConfigValueBoolean,
-  getConfigValueNumber,
   isLocationUserCheckedOut,
   parseBool,
   updateCheckedOutLocationsOnTable,
@@ -37,28 +34,7 @@ describe("functions.js", function () {
     });
   });
 
-  describe("getConfigValue", function () {
-    it("should return default value if none found", function () {
-      expect(getConfigValue(undefined, "default")).toEqual("default");
-    });
 
-    it("should return process env values", function () {
-      process.env.TEST_TEST_TEST = 1;
-      expect(getConfigValue("TEST_TEST_TEST")).toEqual("1");
-    });
-  });
-
-  describe("getConfigValueNumber", function () {
-    it("should return a number given a config number", function () {
-      process.env.TEST_TEST_TEST = 1;
-      expect(getConfigValueNumber("TEST_TEST_TEST")).toEqual(1);
-    });
-
-    it("should return a boolean given a config boolean", function () {
-      process.env.TEST_TEST_TEST = "true";
-      expect(getConfigValueBoolean("TEST_TEST_TEST")).toEqual(true);
-    });
-  });
 
   describe("Review and submit functions", () => {
     describe("checked out location functions", () => {


### PR DESCRIPTION
updated error message in the report generator
updated report params to include year and quarter
updated report component to call the appropriate api with the id, oris code, and year quarter to get eval status code
And to display the report message based on the eval status code and the report generated
moved the utility functions linked to configuration to a separate file