### PR TITLE
fix:letter cut off from the tabe header

### DIFF
--- a/src/styles/_react-datatable-overrides.scss
+++ b/src/styles/_react-datatable-overrides.scss
@@ -114,6 +114,7 @@
     color: $epa-black !important;
     /*white-space: nowrap !important;*/
     margin-right: 1em !important;
+    overflow: visible !important;
   }
   .rdt_TableRow {
     /**/


### PR DESCRIPTION
## Ticket
["t" in Component cutoff in Component Type column](https://app.zenhub.com/workspaces/dpcerg-scrum-board-5f36cc8dfed6db0022b0f4db/issues/gh/us-epa-camd/easey-ui/6044)

## Change

- Allow overflow visible to show all the letters of the table header.

## Steps to test

1. Navigate to Emissions
2. Open Barry
3. Select `Reporting Period` -> 2023 Q3 , `Locations` ->5 ,`View Template` ->Hourly CO2 CEMS View
4. Verify table header