### PR TITLE
Bugfix/6068 Incorrect Submission Status for Emissions in Evaluate screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,10 @@
 .DS_Store
 .env
 .env.*
+.envrc
 
 npm-debug.log*
+.npmrc
 
 # Logs
 logs

--- a/src/components/EvaluateAndSubmit/ColumnMappings.js
+++ b/src/components/EvaluateAndSubmit/ColumnMappings.js
@@ -97,17 +97,14 @@ export const sortByCompletionDateHour = (a, b) => {
 };
 
 export const formatSubmissionWindow = (window) => {
-  if (window === "REQUIRE" || window === "GRANTED") {
-    return "Open";
-  }
-
+  if (!window) return "None";
+  if (window === "REQUIRE" || window === "GRANTED") return "Open";
   return "Closed";
 };
 
 export const formatTimeStamp = (timeStamp) => {
   const date = new Date(timeStamp);
-  return `${date.getFullYear()}-${(date
-    .getMonth() + 1)
+  return `${date.getFullYear()}-${(date.getMonth() + 1)
     .toString()
     .padStart(2, "0")}-${date.getDate().toString().padStart(2, "0")} ${date
     .getHours()
@@ -433,7 +430,7 @@ export const emissionsColumns = [
   },
   {
     name: <span>{"Submission Status"}</span>,
-    selector: (row) => row.submissionAvailabilityCodeDescription,
+    selector: (row) => row.submissionAvailabilityCodeDescription || "None",
     sortable: true,
   },
   {


### PR DESCRIPTION
## Main Changes:
- Updated the `formatSubmissionWindow` function to display "None" when the `windowStatus` is empty. This function previously fell through to "Closed".
- Updated the "Submission Status" display logic to also show "None" when the `submissionAvailabilityCodeDescription` field is empty.