### PR TITLE
fix:componentId and moniteringSystemId read only for submited QA

### DIFF
--- a/src/components/ModalDetails/ModalDetails.js
+++ b/src/components/ModalDetails/ModalDetails.js
@@ -29,6 +29,7 @@ const ModalDetails = ({
   setMainDropdownChange,
   mainDropdownChange,
   setDisableExitBtnStatus,
+  disableColoums
 }) => {
   // fixes resizing issue with calendar date picker along with help in CSS file
   const containerStyle = {
@@ -322,6 +323,7 @@ const ModalDetails = ({
             epa-testid={value[0].split(" ").join("-")}
             name={value[1]}
             secondOption="name"
+            viewOnly={disableColoums && disableColoums.includes(value[0])}
           />
         );
         break;

--- a/src/components/ModalDetails/ModalDetails.js
+++ b/src/components/ModalDetails/ModalDetails.js
@@ -29,7 +29,7 @@ const ModalDetails = ({
   setMainDropdownChange,
   mainDropdownChange,
   setDisableExitBtnStatus,
-  disableColoums
+  disabledColumns
 }) => {
   // fixes resizing issue with calendar date picker along with help in CSS file
   const containerStyle = {
@@ -323,7 +323,7 @@ const ModalDetails = ({
             epa-testid={value[0].split(" ").join("-")}
             name={value[1]}
             secondOption="name"
-            viewOnly={disableColoums && disableColoums.includes(value[0])}
+            viewOnly={disabledColumns && disabledColumns.includes(value[0])}
           />
         );
         break;

--- a/src/components/qaDatatablesContainer/QATestSummaryDataTable/QATestSummaryDataTable.js
+++ b/src/components/qaDatatablesContainer/QATestSummaryDataTable/QATestSummaryDataTable.js
@@ -784,7 +784,7 @@ const QATestSummaryDataTable = ({
                   create={createNewData}
                   setMainDropdownChange={setMainDropdownChange}
                   mainDropdownChange={mainDropdownChange}
-                  disableColoums={!createNewData ? ['componentId','monitoringSystemId']:[]}
+                  disabledColumns={!createNewData ? ['componentId','monitoringSystemId']:[]}
                 />
               </div>
             ) : (

--- a/src/components/qaDatatablesContainer/QATestSummaryDataTable/QATestSummaryDataTable.js
+++ b/src/components/qaDatatablesContainer/QATestSummaryDataTable/QATestSummaryDataTable.js
@@ -784,6 +784,7 @@ const QATestSummaryDataTable = ({
                   create={createNewData}
                   setMainDropdownChange={setMainDropdownChange}
                   mainDropdownChange={mainDropdownChange}
+                  disableColoums={!createNewData ? ['componentId','monitoringSystemId']:[]}
                 />
               </div>
             ) : (


### PR DESCRIPTION
## Ticket
[Make component and system ID fields read-only for submitted QA tests](https://github.com/US-EPA-CAMD/easey-ui/issues/6060)

## Changes
`componentId` and `monitoringSystemId` read only for submited QA test data
