### PR TITLE
fix:second normal indicator radio button to dropdown

### DIFF
--- a/src/additional-functions/dataTable-props.js
+++ b/src/additional-functions/dataTable-props.js
@@ -141,7 +141,17 @@ export const loadsDataTableProps = (location) => {
       upperOperationBoundary: ["Upper Operation Boundary", "input", "", ""],
       normalLevelCode: ["Normal Level", "independentDropdown", "", ""],
       secondLevelCode: ["Second Level", "independentDropdown", "", ""],
-      secondNormalIndicator: ["Second Normal Indicator", "radio", "", ""],
+      secondNormalIndicator: [
+        "Second Normal Indicator",
+        "customDropdown",
+        "",
+        "",
+        [
+          { code: null, name: "--- Select a Value ---" },
+          { code: 1, name: "Yes" },
+          { code: 0, name: "No" },
+        ],
+      ],
     },
     controlDatePickerInputs: {
       loadAnalysisDate: ["Load Analysis Date", "date", "", ""],

--- a/src/components/MonitoringPlanTabRender/MonitoringPlanTabRender.js
+++ b/src/components/MonitoringPlanTabRender/MonitoringPlanTabRender.js
@@ -148,7 +148,6 @@ export const MonitoringPlanTabRender = ({
                   "controlDatePickerInputs"
                 ]
               }
-              radioNames={["secondNormalIndicator"]}
               dataTableName={"Load"}
               revertedState={revertedState}
               setRevertedState={setRevertedState}

--- a/src/utils/selectors/monitoringPlanLoads.js
+++ b/src/utils/selectors/monitoringPlanLoads.js
@@ -13,7 +13,7 @@ export const getMonitoringPlansLoadsTableRecords = (totalData) => {
         secondNormalIndicator = "No";
       }
     } else {
-      secondNormalIndicator = "";
+      secondNormalIndicator = null;
     }
 
     let maximumLoadUnitsOfMeasureCode;


### PR DESCRIPTION
## Ticket
[Add null option for Load - Second Normal Indicator](https://github.com/US-EPA-CAMD/easey-ui/issues/6059)

## Change

- Second Normal Indicator radio button changed to dropdown 