### PR TITLE
fix:remove system component have length condition

### DIFF
--- a/src/components/ModalAddComponent/ModalAddComponent.js
+++ b/src/components/ModalAddComponent/ModalAddComponent.js
@@ -47,17 +47,15 @@ const ModalAddComponent = ({
   useEffect(() => {
     let options = [];
 
-    if (filteredComps.length >= 1 && unlinkedComponentsOptions.length < 1) {
-      options = filteredComps.map((option) => {
-        return {
-          code: option["id"],
-          name: `${option["componentId"]} / ${option["componentTypeCode"]}`,
-        };
-      });
+    options = filteredComps.map((option) => {
+      return {
+        code: option["id"],
+        name: `${option["componentId"]} / ${option["componentTypeCode"]}`,
+      };
+    });
 
-      options.unshift({ code: "", name: "--- Select a value ---" });
-      setUnlinkedComponentsOptions(options);
-    }
+    options.unshift({ code: "", name: "--- Select a value ---" });
+    setUnlinkedComponentsOptions(options);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [filteredComps]);
 

--- a/src/components/ModalAddComponent/ModalAddComponent.js
+++ b/src/components/ModalAddComponent/ModalAddComponent.js
@@ -35,13 +35,11 @@ const ModalAddComponent = ({
     } else {
       main = comps;
 
-      if (sysComps.length >= 1) {
-        const sysWithEndDate = sysComps.filter((sy) => sy.endDate && new Date(sy.endDate) < new Date());
-        const componetWithSystemEndDate = main.filter(({ componentId }) => sysWithEndDate.some(({ componentId: sysCompId }) => sysCompId === componentId));
-        main = main.filter(({ componentId }) => !sysComps.some(({ componentId: sysCompId }) => sysCompId === componentId));
-        const filterCompos = [...main, ...componetWithSystemEndDate];
-        setFilteredComps(filterCompos);
-      }
+      const sysWithEndDate = sysComps.filter((sy) => sy.endDate && new Date(sy.endDate) < new Date());
+      const componetWithSystemEndDate = main.filter(({ componentId }) => sysWithEndDate.some(({ componentId: sysCompId }) => sysCompId === componentId));
+      main = main.filter(({ componentId }) => !sysComps.some(({ componentId: sysCompId }) => sysCompId === componentId));
+      const filterCompos = [...main, ...componetWithSystemEndDate];
+      setFilteredComps(filterCompos);
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Ticket
[Systems - add component popup window when adding a new system - Dropdown Issue](https://github.com/US-EPA-CAMD/easey-ui/issues/5998)

## Change

- Removed the if condition of `sysComps.length >= 1`