### PR TITLE
fix:remove space from analyzer-range API

### DIFF
--- a/src/utils/api/monitoringPlansApi.js
+++ b/src/utils/api/monitoringPlansApi.js
@@ -119,7 +119,7 @@ export const getMonitoringComponents = async (locId) => {
 
 export const getMonitoringAnalyzerRanges = async (locId, componentRecordId) => {
   const url = getApiUrl(
-    `/locations/${locId}​/components/${componentRecordId}/analyzer-ranges`
+    `/locations/${locId}/components/${componentRecordId}/analyzer-ranges`
   );
   return secureAxios({
     method: "GET",


### PR DESCRIPTION
## Ticket
[Viewing system component in workspace issue (forbidden resource)](https://github.com/US-EPA-CAMD/easey-ui/issues/5948)

## Change

- Remove extra space (%E2%80%8B) from analyzer-ranges GET API
## Step to test

1. Checkout Mill Creek 1364 1,2,CS12
2. Select Systems from Monitoring Plans
3. Select View System ID 130
4. Select View Component ID 001


Note:  if we select location/locId as `72`, it will be at `727%E2%80%8B`,. Currently (4/10/2024) Dev environment is bypassing the cdx, so test in test environment
