### PR TITLE
fix:update reporting periods state after import historical

### DIFF
--- a/src/components/HeaderInfo/HeaderInfo.js
+++ b/src/components/HeaderInfo/HeaderInfo.js
@@ -931,6 +931,7 @@ export const HeaderInfo = ({
     });
 
     setSelectedReportingPeriods([importedReportingPeriod])
+    dispatch(setReportingPeriods([importedReportingPeriod], currentTab.name, workspaceSection));
   };
 
   // Create audit message for header info


### PR DESCRIPTION
## Ticket
[Reporting Period Dropdown Issue in Emissions Module](https://github.com/US-EPA-CAMD/easey-ui/issues/6049)

## Changes

- update `reportingPeriods` state after import historical