### PR TITLE
fix:filtercompns arry unique with componentId and componentTypeCode

### DIFF
--- a/src/components/ModalAddComponent/ModalAddComponent.js
+++ b/src/components/ModalAddComponent/ModalAddComponent.js
@@ -35,9 +35,16 @@ const ModalAddComponent = ({
     } else {
       main = comps;
 
+      //Filtering system component with system endDate
       const sysWithEndDate = sysComps.filter((sy) => sy.endDate && new Date(sy.endDate) < new Date());
+
+      // selecting component from main. that has componentId is equal to sysWithEndDate's componentId
       const componetWithSystemEndDate = main.filter(({ componentId }) => sysWithEndDate.some(({ componentId: sysCompId }) => sysCompId === componentId));
+
+      // components associated with a monitor location that are NOT already active at the system.
       main = main.filter(({ componentId }) => !sysComps.some(({ componentId: sysCompId }) => sysCompId === componentId));
+
+      // merge main and componetWithSystemEndDate. then unique with 'componentId', 'componentTypeCode'
       const filterCompos = [...main, ...componetWithSystemEndDate].filter((obj1, index, arr) => arr.findIndex(obj2 => ['componentId', 'componentTypeCode'].every(item => obj2[item] === obj1[item])) === index);
       setFilteredComps(filterCompos);
     }

--- a/src/components/ModalAddComponent/ModalAddComponent.js
+++ b/src/components/ModalAddComponent/ModalAddComponent.js
@@ -38,7 +38,7 @@ const ModalAddComponent = ({
       const sysWithEndDate = sysComps.filter((sy) => sy.endDate && new Date(sy.endDate) < new Date());
       const componetWithSystemEndDate = main.filter(({ componentId }) => sysWithEndDate.some(({ componentId: sysCompId }) => sysCompId === componentId));
       main = main.filter(({ componentId }) => !sysComps.some(({ componentId: sysCompId }) => sysCompId === componentId));
-      const filterCompos = [...main, ...componetWithSystemEndDate];
+      const filterCompos = [...main, ...componetWithSystemEndDate].filter((obj1, index, arr) => arr.findIndex(obj2 => ['componentId', 'componentTypeCode'].every(item => obj2[item] === obj1[item])) === index);
       setFilteredComps(filterCompos);
     }
 


### PR DESCRIPTION
## Ticket
[unique component dropdown list](https://github.com/US-EPA-CAMD/easey-ui/issues/5876#issuecomment-2043514732)


## Change

- added a filter for unique the filterCompos with 'componentId', 'componentTypeCode'