### PR TITLE
fix:remove active components from the dropdown and sort with componentId

### DIFF
--- a/src/components/ModalAddComponent/ModalAddComponent.js
+++ b/src/components/ModalAddComponent/ModalAddComponent.js
@@ -45,13 +45,12 @@ const ModalAddComponent = ({
       const componetWithSystemEndDate = main.filter(({ componentId }) => sysWithEndDate.some(({ componentId: sysCompId }) => sysCompId === componentId));
 
       // remove active components 
-      const componentWithNonActive = componetWithSystemEndDate.filter(({ componentId, componentTypeCode }) => !activeSystem.some(({ componentId: sysCompId, componentTypeCode: sysCompType }) => sysCompId === componentId && componentTypeCode === sysCompType))
-      
+      const componentWithNonActive = componetWithSystemEndDate.filter(({ componentId }) => !activeSystem.some(({ componentId: sysCompId }) => sysCompId === componentId))
       // components associated with a monitor location that are NOT already active at the system.
       main = main.filter(({ componentId }) => !sysComps.some(({ componentId: sysCompId }) => sysCompId === componentId));
 
-      // merge main and componetWithSystemEndDate. then unique with 'componentId', 'componentTypeCode' | Sort by componentId
-      const filterCompos = [...main, ...componentWithNonActive].filter((obj1, index, arr) => arr.findIndex(obj2 => ['componentId', 'componentTypeCode'].every(item => obj2[item] === obj1[item])) === index).sort((a,b)=>a.componentId - b.componentId);
+      // merge main and componetWithSystemEndDate. then unique with 'componentId' | Sort by componentId
+      const filterCompos = [...main, ...componentWithNonActive].filter((obj1, index, arr) => arr.findIndex(obj2 => ['componentId'].every(item => obj2[item] === obj1[item])) === index).sort((a, b) => a.componentId - b.componentId || a.componentId.localeCompare(b.componentId));
       setFilteredComps(filterCompos);
     }
 

--- a/src/components/ModalAddComponent/ModalAddComponent.js
+++ b/src/components/ModalAddComponent/ModalAddComponent.js
@@ -38,14 +38,20 @@ const ModalAddComponent = ({
       //Filtering system component with system endDate
       const sysWithEndDate = sysComps.filter((sy) => sy.endDate && new Date(sy.endDate) < new Date());
 
+      //Filtering system component with active | no endDate
+      const activeSystem = sysComps.filter((sy) => !sy.endDate || new Date(sy?.endDate) > new Date());
+
       // selecting component from main. that has componentId is equal to sysWithEndDate's componentId
       const componetWithSystemEndDate = main.filter(({ componentId }) => sysWithEndDate.some(({ componentId: sysCompId }) => sysCompId === componentId));
 
+      // remove active components 
+      const componentWithNonActive = componetWithSystemEndDate.filter(({ componentId, componentTypeCode }) => !activeSystem.some(({ componentId: sysCompId, componentTypeCode: sysCompType }) => sysCompId === componentId && componentTypeCode === sysCompType))
+      
       // components associated with a monitor location that are NOT already active at the system.
       main = main.filter(({ componentId }) => !sysComps.some(({ componentId: sysCompId }) => sysCompId === componentId));
 
-      // merge main and componetWithSystemEndDate. then unique with 'componentId', 'componentTypeCode'
-      const filterCompos = [...main, ...componetWithSystemEndDate].filter((obj1, index, arr) => arr.findIndex(obj2 => ['componentId', 'componentTypeCode'].every(item => obj2[item] === obj1[item])) === index);
+      // merge main and componetWithSystemEndDate. then unique with 'componentId', 'componentTypeCode' | Sort by componentId
+      const filterCompos = [...main, ...componentWithNonActive].filter((obj1, index, arr) => arr.findIndex(obj2 => ['componentId', 'componentTypeCode'].every(item => obj2[item] === obj1[item])) === index).sort((a,b)=>a.componentId - b.componentId);
       setFilteredComps(filterCompos);
     }
 


### PR DESCRIPTION
## Ticket 
[Remove active component from dropdown](https://github.com/US-EPA-CAMD/easey-ui/issues/5876#issuecomment-2064989303)

## Change

1. Remove active component from dropdown
2. Sort dropdown list by componentId