### PR TITLE
Fix/5897 formula error messaging

### DIFF
--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -33,7 +33,7 @@ export const Modal = ({
     width: window.innerWidth,
     height: window.innerHeight,
   });
-  
+
   if (windowSize.width <= 1300) {
     width = "650px";
   } else {
@@ -44,7 +44,7 @@ export const Modal = ({
       setWindowSize({
         width: window.innerWidth,
         height: window.innerHeight,
-      }); 
+      });
     };
 
     window.addEventListener("resize", handleResize);
@@ -138,11 +138,19 @@ export const Modal = ({
 
                   {breadCrumbBar ? breadCrumbBar : ""}
 
-                  {errorMsgs.map((error) => (
-                    <Alert type="error" slim noIcon key={error} role="alert">
-                      {error}
-                    </Alert>
-                  ))}
+                  {errorMsgs
+                    .flatMap((error) => {
+                      try {
+                        return JSON.parse(error); // May be a stringified array
+                      } catch {
+                        return error;
+                      }
+                    })
+                    .map((error) => (
+                      <Alert type="error" slim noIcon key={error} role="alert">
+                        {error}
+                      </Alert>
+                    ))}
                 </div>
               </div>
 

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -138,19 +138,11 @@ export const Modal = ({
 
                   {breadCrumbBar ? breadCrumbBar : ""}
 
-                  {errorMsgs
-                    .flatMap((error) => {
-                      try {
-                        return JSON.parse(error); // May be a stringified array
-                      } catch {
-                        return error;
-                      }
-                    })
-                    .map((error) => (
-                      <Alert type="error" slim noIcon key={error} role="alert">
-                        {error}
-                      </Alert>
-                    ))}
+                  {errorMsgs.map((error) => (
+                    <Alert type="error" slim noIcon key={error} role="alert">
+                      {error}
+                    </Alert>
+                  ))}
                 </div>
               </div>
 

--- a/src/components/datatablesContainer/DataTableAssert/DataTableAssert.js
+++ b/src/components/datatablesContainer/DataTableAssert/DataTableAssert.js
@@ -34,7 +34,17 @@ import {
   removeChangeEventListeners,
   unsavedDataMessage,
 } from "../../../additional-functions/prompt-to-save-unsaved-changes";
-import { returnsFocusMpDatatableCreateBTN } from '../../../additional-functions/ensure-508'
+import { returnsFocusMpDatatableCreateBTN } from "../../../additional-functions/ensure-508";
+
+const getErrorListFromResponse = (resp) => {
+  let errors;
+  try {
+    errors = JSON.parse(resp);
+  } catch {
+    errors = resp;
+  }
+  return Array.isArray(errors) ? errors : [errors];
+};
 
 export const DataTableAssert = ({
   mdmData,
@@ -111,7 +121,6 @@ export const DataTableAssert = ({
     }
   }, [dataLoaded, dropdownsLoaded]);
   // *** Reassign handlers when inactive checkbox is toggled
-
 
   // *** Reassign handlers after pop-up modal is closed
   useEffect(() => {
@@ -305,8 +314,7 @@ export const DataTableAssert = ({
         setUpdateTable(true);
         setUpdateRelatedTables(true);
       } else {
-        const errorResp = Array.isArray(resp) ? resp : [resp];
-        setErrorMsgs(errorResp);
+        setErrorMsgs(getErrorListFromResponse(resp));
       }
     } catch (error) {
       setErrorMsgs([JSON.stringify(error)]);
@@ -338,8 +346,7 @@ export const DataTableAssert = ({
         setUpdateTable(true);
         setUpdateRelatedTables(true);
       } else {
-        const errorResp = Array.isArray(resp) ? resp : [resp];
-        setErrorMsgs(errorResp);
+        setErrorMsgs(getErrorListFromResponse(resp));
       }
     } catch (error) {
       setErrorMsgs([JSON.stringify(error)]);
@@ -360,12 +367,11 @@ export const DataTableAssert = ({
         for (const modalDetailData of selectedModalData) {
           if (modalDetailData[4] === "dropdown") {
             const selectedCodes = result[0];
-            const codeName = modalDetailData[0]
+            const codeName = modalDetailData[0];
 
-            const filteredOutSubDropdownOptions = mdmData[codeName]
-              .filter((option) =>
-                selectedCodes[codeName].includes(option.code)
-              );
+            const filteredOutSubDropdownOptions = mdmData[codeName].filter(
+              (option) => selectedCodes[codeName].includes(option.code)
+            );
             filteredOutSubDropdownOptions.unshift({
               code: "",
               name: selectText,
@@ -501,9 +507,10 @@ export const DataTableAssert = ({
     setShow(false);
     removeChangeEventListeners(".modalUserInput");
     if (createNewData) {
-      returnsFocusMpDatatableCreateBTN(`Create ${dataTableName}`)
+      returnsFocusMpDatatableCreateBTN(`Create ${dataTableName}`);
     }
   };
+
   if (document) {
     changeGridCellAttributeValue();
   }


### PR DESCRIPTION
## Related Issues:
- [#5897](https://github.com/US-EPA-CAMD/easey-ui/issues/5897)

## Main Changes:
- Added logic to try to parse error messages from responses before setting them on a modal. This fixes an issue where JSON arrays of errors were not being split out into separate alerts.

## Steps to Test:
1. Navigate to the **Monitoring Plans** module, and check out **Morgantown** (ORIS 1573), configuration **1**.
2. In the _Sections_ dropdown, select **Spans**.
3. Click _View / Edit_ in the row with Component Type **SO2** and Span Scale **L**.
4. Clear the input box for the _MEC Value_ field, and set the input for _Scale Transition Point_ to **51**.
5. Click _Save and Close_.
6. Confirm two separate alerts are shown.

## TODO:
- [ ] Merge this in Sprint 5 **after the ICAM / TypeORM changes have been tested**.