### PR TITLE
displaying component specific field

### DIFF
--- a/src/components/datatablesContainer/DataTableSystems/DataTableSystems.js
+++ b/src/components/datatablesContainer/DataTableSystems/DataTableSystems.js
@@ -360,6 +360,7 @@ export const DataTableSystems = ({
     useState(false);
   const [updateFuelFlowTable, setUpdateFuelFlowTable] = useState(false);
   const [updateComponentTable, setupdateComponentTable] = useState(false);
+  const [updateComponentList, setupdateComponentList] = useState(false);
   const [createAnalyzerRangesFlag, setCreateAnalyzerRangesFlag] =
     useState(false);
   const [createFuelFlowFlag, setCreateFuelFlowFlag] = useState(false);
@@ -967,6 +968,8 @@ export const DataTableSystems = ({
                   // setCreateBtnAPI={setCreateBtnAPI}
                   updateComponentTable={updateComponentTable}
                   setupdateComponentTable={setupdateComponentTable}
+                  updateComponentList={updateComponentList}
+                  setupdateComponentList={setupdateComponentList}
                   updateAnalyzerRangeTable={updateAnalyzerRangeTable}
                   setUpdateAnalyzerRangeTable={setUpdateAnalyzerRangeTable}
                   setCreateAnalyzerRangesFlag={setCreateAnalyzerRangesFlag}

--- a/src/components/datatablesContainer/DataTableSystemsComponents/DataTableSystemsComponents.js
+++ b/src/components/datatablesContainer/DataTableSystemsComponents/DataTableSystemsComponents.js
@@ -59,6 +59,8 @@ export const DataTableSystemsComponents = ({
   createNewComponentFlag,
   updateComponentTable,
   setupdateComponentTable,
+  updateComponentList,
+  setupdateComponentList,
   addComponentFlag,
   setAddComponentFlag,
   addExistingComponentFlag,
@@ -82,6 +84,7 @@ export const DataTableSystemsComponents = ({
 
   const selectText = "-- Select a value --";
   const [dataLoaded, setDataLoaded] = useState(false);
+  const [dataComponentsLoaded, setDataComponentsLoaded] = useState(false);
   const [dataFuelLoaded, setFuelDataLoaded] = useState(false);
   const [selectedModalData, setSelectedModalData] = useState(null);
   const [selectedComponentsModalData, setSelectedComponentsModalData] =
@@ -92,6 +95,7 @@ export const DataTableSystemsComponents = ({
 
   const [monitoringSystemsComponents, setMonitoringSystemsComponents] =
     useState("");
+  const [monitoringComponents, setMonitoringComponents] = useState("");
 
   const [fuelFlowDropdownsLoaded, setFuelFlowDropdownsLoaded] = useState(false);
   const [systemComponentDropdownsLoaded, setSystemComponentDropdownsLoaded] =
@@ -199,7 +203,7 @@ export const DataTableSystemsComponents = ({
         }
       }
     })
-    .catch(error => console.log('getMonitoringSystems failed', error));
+      .catch(error => console.log('getMonitoringSystems failed', error));
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [systemID]);
@@ -216,6 +220,15 @@ export const DataTableSystemsComponents = ({
         .catch(error => console.log('getMonitoringSystemsComponents failed', error));
 
       mpApi
+        .getMonitoringComponents(selected.locationId)
+        .then((res) => {
+          setMonitoringComponents(res.data);
+          setDataComponentsLoaded(true);
+          setupdateComponentList(false);
+        })
+        .catch(error => console.log('getMonitoringComponents failed', error));
+
+      mpApi
         .getMonitoringSystemsFuelFlows(selected.locationId, selected.id)
         .then((res) => {
           setMonitoringSystemsFuelFlows(res.data);
@@ -225,7 +238,7 @@ export const DataTableSystemsComponents = ({
         .catch(error => console.log('getMonitoringSystemsFuelFlows failed', error));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selected, updateFuelFlowTable, updateComponentTable]);
+  }, [selected, updateFuelFlowTable, updateComponentTable, updateComponentList]);
 
   // triggers on change prefilter of systems component
   useEffect(() => {
@@ -376,6 +389,17 @@ export const DataTableSystemsComponents = ({
 
     if (monitoringSystemsComponents.length > 0 && !create) {
       selectComponents = monitoringSystemsComponents.find(sysComp => sysComp.id === row.id)
+      const associatedComponent = monitoringComponents.find((com) => com.componentId === selectComponents?.componentId)
+
+      selectComponents['sampleAcquisitionMethodCode'] = associatedComponent?.sampleAcquisitionMethodCode;
+      selectComponents['componentTypeCode'] = associatedComponent?.componentTypeCode;
+      selectComponents['basisCode'] = associatedComponent?.basisCode;
+      selectComponents['analyticalPrincipleCode'] = associatedComponent?.analyticalPrincipleCode;
+      selectComponents['manufacturer'] = associatedComponent?.manufacturer;
+      selectComponents['modelVersion'] = associatedComponent?.modelVersion;
+      selectComponents['serialNumber'] = associatedComponent?.serialNumber;
+      selectComponents['hgConverterIndicator'] = associatedComponent?.hgConverterIndicator;
+      selectComponents['analyzerRangeData'] = associatedComponent?.analyzerRangeData;
 
       setSelectedComponent(selectComponents);
       setOpenAnalyzer(selectComponents);
@@ -507,14 +531,14 @@ export const DataTableSystemsComponents = ({
   };
 
   const data = useMemo(() => {
-    if (monitoringSystemsComponents.length > 0) {
+    if (monitoringSystemsComponents.length > 0 && monitoringComponents.length > 0) {
       return fs.getMonitoringPlansSystemsComponentsTableRecords(
-        monitoringSystemsComponents
+        monitoringSystemsComponents, monitoringComponents
       );
     } else {
       return [];
     }
-  }, [monitoringSystemsComponents]);
+  }, [monitoringSystemsComponents, monitoringComponents]);
 
   const fuelFlowsData = useMemo(() => {
     if (monitoringSystemsFuelFlows.length > 0) {
@@ -566,7 +590,7 @@ export const DataTableSystemsComponents = ({
                   openHandler={openComponent}
                   tableTitle="System Components"
                   componentStyling="systemsCompTable"
-                  dataLoaded={dataLoaded && systemComponentDropdownsLoaded}
+                  dataLoaded={dataLoaded && systemComponentDropdownsLoaded && dataComponentsLoaded}
                   actionsBtn={"View"}
                   user={user}
                   checkout={checkout}

--- a/src/components/datatablesContainer/DataTableSystemsComponents/DataTableSystemsComponents.test.js
+++ b/src/components/datatablesContainer/DataTableSystemsComponents/DataTableSystemsComponents.test.js
@@ -16,6 +16,7 @@ import {
   getMonitoringSystems,
   getMonitoringSystemsComponents,
   getMonitoringSystemsFuelFlows,
+  getMonitoringComponents
 } from '../../../utils/api/monitoringPlansApi';
 const axios = require('axios');
 
@@ -23,6 +24,7 @@ jest.mock('axios');
 jest.mock('../../../utils/api/monitoringPlansApi', () => ({
   getMonitoringSystems: jest.fn(),
   getMonitoringSystemsComponents: jest.fn(),
+  getMonitoringComponents:jest.fn(),
   getMonitoringSystemsFuelFlows: jest.fn(),
 }));
 const selectedSystem = [
@@ -377,6 +379,7 @@ describe('DatatableSystemsComponents test suit', () => {
   test('tests a getMonitoringSystemsComponents', async () => {
     const createMock = data => jest.fn().mockResolvedValue({ data });
     getMonitoringSystemsComponents.mockImplementation(createMock(apiComp));
+    getMonitoringComponents.mockImplementation(createMock(apiComp));
     getMonitoringSystems.mockImplementation(createMock(selectedSystem));
     getMonitoringSystemsFuelFlows.mockImplementation(createMock(apiFuel));
 
@@ -417,6 +420,7 @@ describe('DatatableSystemsComponents test suit', () => {
   test('tests a getMonitoringSystemsFuelFlows', async () => {
     const createMock = data => jest.fn().mockResolvedValue({ data });
     getMonitoringSystemsComponents.mockImplementation(createMock(apiComp));
+    getMonitoringComponents.mockImplementation(createMock(apiComp));
     getMonitoringSystems.mockImplementation(createMock(selectedSystem));
     getMonitoringSystemsFuelFlows.mockImplementation(createMock(apiFuel));
     // axios.get.mockImplementation(() =>
@@ -445,6 +449,7 @@ describe('DatatableSystemsComponents test suit', () => {
     // );
     const createMock = data => jest.fn().mockResolvedValue({ data });
     getMonitoringSystemsComponents.mockImplementation(createMock(apiComp));
+    getMonitoringComponents.mockImplementation(createMock(apiComp));
     getMonitoringSystems.mockImplementation(createMock(selectedSystem));
     getMonitoringSystemsFuelFlows.mockImplementation(createMock(apiFuel));
     const title = await getMonitoringSystemsFuelFlows(

--- a/src/utils/selectors/monitoringPlanSystems.js
+++ b/src/utils/selectors/monitoringPlanSystems.js
@@ -16,9 +16,10 @@ export const getMonitoringPlansSystemsTableRecords = (data) => {
   return records;
 };
 
-export const getMonitoringPlansSystemsComponentsTableRecords = (data) => {
+export const getMonitoringPlansSystemsComponentsTableRecords = (monitoringSystemsComponents, monitoringComponents) => {
   const records = [];
-  data.forEach((el) => {
+  monitoringSystemsComponents.forEach((el) => {
+    const associatedComponent = monitoringComponents.find((com)=>com.componentId === el.componentId)
     let present;
     if (el.endDate === "" || el.endDate === undefined) {
       present = "Present";
@@ -28,7 +29,7 @@ export const getMonitoringPlansSystemsComponentsTableRecords = (data) => {
     records.push({
       id: el.id,
       col1: el.componentId,
-      col2: el.componentTypeCode,
+      col2: associatedComponent?.componentTypeCode,
       col3: `${formatDateTime(el.beginDate, el.beginHour)} ➜ ${present}`.trim(),
     });
   });

--- a/src/utils/selectors/monitoringPlanSystems.test.js
+++ b/src/utils/selectors/monitoringPlanSystems.test.js
@@ -9,6 +9,7 @@ describe("testing monitoring plan data selectors", () => {
   let selectedMonitoringSystemsFuelFlow;
   let selectedMonitoringSystemsRanges;
   let monitoringSystemsRangesTableRecods;
+  let monitoringComponents;
 
   beforeAll(() => {
     selectedMonitoringSystems = [
@@ -89,6 +90,33 @@ describe("testing monitoring plan data selectors", () => {
         beginHour: null,
       },
     ];
+
+    monitoringComponents = [
+      {
+        componentId: "AFA",
+        componentTypeCode: "GFFM",
+        analyticalPrincipleCode : null,
+        sampleAcquisitionMethodCode: "ORF",
+        basisCode : null,
+        manufacturer: "SCHNEIDER",
+        modelVersion: "RTT1SS-T1SA1-EN",
+        serialNumber: 17301602,
+        hgConverterIndicator : null,
+        analyzerRangeData : []
+      },
+      {
+        componentId: "AFG",
+        componentTypeCode: "TEMP",
+        analyticalPrincipleCode: null,
+        sampleAcquisitionMethodCode: "ORF",
+        basisCode: null,
+        manufacturer: "SCHNEIDER",
+        modelVersion: "RTT1SS-T1SA1-EN",
+        serialNumber: "17301603",
+        hgConverterIndicator: null,
+        analyzerRangeData: []
+      },
+    ]
 
     selectedMonitoringSystemsFuelFlow = [
       {
@@ -264,7 +292,7 @@ describe("testing monitoring plan data selectors", () => {
   test("should generate data table records for monitoring systems components", () => {
     expect(
       fs.getMonitoringPlansSystemsComponentsTableRecords(
-        selectedMonitoringSystemsComponents
+        selectedMonitoringSystemsComponents, monitoringComponents
       )
     ).toEqual(monitoringSystemsComponentsTableRecods);
   });


### PR DESCRIPTION
## Ticket
[Monitoring Plan Export Bug: Remove component specific fields from the monitoringSystemComponentData records](https://github.com/US-EPA-CAMD/easey-ui/issues/6223)

## Changes
For displaying component specific field selecting the associated componentData by using monitoringSystemComponentData’s componentId.