### PR TITLE
added associate component id to componentRecordId

### DIFF
--- a/src/components/datatablesContainer/DataTableSystemsComponents/DataTableSystemsComponents.js
+++ b/src/components/datatablesContainer/DataTableSystemsComponents/DataTableSystemsComponents.js
@@ -400,6 +400,7 @@ export const DataTableSystemsComponents = ({
       selectComponents['serialNumber'] = associatedComponent?.serialNumber;
       selectComponents['hgConverterIndicator'] = associatedComponent?.hgConverterIndicator;
       selectComponents['analyzerRangeData'] = associatedComponent?.analyzerRangeData;
+      selectComponents['componentRecordId'] = associatedComponent?.id;
 
       setSelectedComponent(selectComponents);
       setOpenAnalyzer(selectComponents);


### PR DESCRIPTION
## Ticket
[Analyzer ranges currently not visible](https://github.com/US-EPA-CAMD/easey-ui/issues/5948#issuecomment-2142706605)

## Changes

- Added componentRecordId from associated component id for calling Analyzer Range endpoints 