### PR TITLE
added resetEmissionWorkspace function and reset the workspace

### DIFF
--- a/src/components/HeaderInfo/HeaderInfo.js
+++ b/src/components/HeaderInfo/HeaderInfo.js
@@ -852,7 +852,22 @@ export const HeaderInfo = ({
     // this code executes first while we wait for api to finish returning
     setIsReverting(true);
     setShowRevertModal(false);
+    resetEmissionsWorkspace();
   };
+
+  const resetEmissionsWorkspace = () => {
+
+    // set Default Reporting period
+    setSelectedReportingPeriods([reportingPeriods[0]?.id]);
+    dispatch(
+      setReportingPeriods([reportingPeriods[0]?.id], currentTab.name, EMISSIONS_STORE_NAME)
+    );
+
+    dispatch(setViewDataColumns([], currentTab.name, EMISSIONS_STORE_NAME));
+    dispatch(setViewData([], currentTab.name, EMISSIONS_STORE_NAME));
+    dispatch(setViewTemplateSelectionAction(null, currentTab.name, EMISSIONS_STORE_NAME));
+    setDefaultReportingPeriodChanged(true);
+  }
 
   const importMPFile = (payload) => {
     setIsLoading(true);


### PR DESCRIPTION
## Ticket
[Emissions Screen viewCode Error after Reverting to Official](https://github.com/US-EPA-CAMD/easey-ui/issues/6237)

## Change


- After official reset, set default reporting period and reset viewDataColumn, viewData, ViewTemplate