### PR TITLE
Bug: Add QACERT-11-A QCE screen check

### DIFF
--- a/src/components/QADataTableRender/QADataTableRender.js
+++ b/src/components/QADataTableRender/QADataTableRender.js
@@ -210,7 +210,7 @@ const QADataTableRender = ({
                         {"Edit"}
                       </Button>
 
-                      {!row.isSubmitted && (
+                      {!row?.isSubmitted && (
                         <RemoveButton
                           row={row}
                           dataTableName={dataTableName}

--- a/src/components/qaDatatablesContainer/QACertEventTestExmpDataTable/QACertEventTestExmpDataTable.js
+++ b/src/components/qaDatatablesContainer/QACertEventTestExmpDataTable/QACertEventTestExmpDataTable.js
@@ -481,9 +481,14 @@ const QACertEventTestExmpDataTable = ({
     const userInput = extractUserInput(payload, ".modalUserInput");
 
     // check if the monitoring system id and Component id are null or empty
-    if (!userInput.monitoringSystemId || !userInput.componentId) {
+    if (!userInput.monitoringSystemId || !userInput.componentId || !userInput.certificationEventCode || !userInput.requiredTestCode) {
       const errorMsgs = [
-        !userInput.monitoringSystemId && !userInput.componentId ? "Monitoring System ID and Component ID should not be empty" : !userInput.monitoringSystemId ? "Monitoring System ID should not be empty" : !userInput.componentId ? "Component ID should not be empty" : "",
+        !userInput.monitoringSystemId && !userInput.componentId && !userInput.certificationEventCode && !userInput.requiredTestCode ? "Monitoring System ID, Component ID, QA Cert Event Code, and Required Test Code should not be empty" :
+        !userInput.monitoringSystemId && !userInput.componentId ? "Monitoring System ID and Component ID should not be empty" :
+        !userInput.monitoringSystemId ? "Monitoring System ID should not be empty" :
+        !userInput.componentId ? "Component ID should not be empty" :
+        !userInput.certificationEventCode ? "QA Cert Event Code should not be empty" :
+        !userInput.requiredTestCode ? "Required Test Code should not be empty" : ""
       ];
       setErrorMsgs(errorMsgs);
       return;
@@ -507,6 +512,7 @@ const QACertEventTestExmpDataTable = ({
 
   const createData = async () => {
     const userInput = extractUserInput(payload, ".modalUserInput");
+    console.log("userInput", userInput);
     if (userInput.unitId) {
       userInput.unitId = String(userInput.unitId);
       userInput.stackPipeId = null;
@@ -515,9 +521,14 @@ const QACertEventTestExmpDataTable = ({
       userInput.unitId = null;
     }
     // check if the monitoring system id and Component id are null or empty
-    if (!userInput.monitoringSystemId || !userInput.componentId) {
+    if (!userInput.monitoringSystemId || !userInput.componentId || !userInput.certificationEventCode || !userInput.requiredTestCode) {
       const errorMsgs = [
-        !userInput.monitoringSystemId && !userInput.componentId ? "Monitoring System ID and Component ID should not be empty" : !userInput.monitoringSystemId ? "Monitoring System ID should not be empty" : !userInput.componentId ? "Component ID should not be empty" : ""
+        !userInput.monitoringSystemId && !userInput.componentId && !userInput.certificationEventCode && !userInput.requiredTestCode ? "Monitoring System ID, Component ID, QA Cert Event Code, and Required Test Code should not be empty" :
+        !userInput.monitoringSystemId && !userInput.componentId ? "Monitoring System ID and Component ID should not be empty" :
+        !userInput.monitoringSystemId ? "Monitoring System ID should not be empty" :
+        !userInput.componentId ? "Component ID should not be empty" :
+        !userInput.certificationEventCode ? "QA Cert Event Code should not be empty" :
+        !userInput.requiredTestCode ? "Required Test Code should not be empty" : ""
       ];
       setErrorMsgs(errorMsgs);
       return;

--- a/src/components/qaDatatablesContainer/QACertEventTestExmpDataTable/QACertEventTestExmpDataTable.js
+++ b/src/components/qaDatatablesContainer/QACertEventTestExmpDataTable/QACertEventTestExmpDataTable.js
@@ -512,7 +512,6 @@ const QACertEventTestExmpDataTable = ({
 
   const createData = async () => {
     const userInput = extractUserInput(payload, ".modalUserInput");
-    console.log("userInput", userInput);
     if (userInput.unitId) {
       userInput.unitId = String(userInput.unitId);
       userInput.stackPipeId = null;

--- a/src/components/qaDatatablesContainer/QACertEventTestExmpDataTable/QACertEventTestExmpDataTable.js
+++ b/src/components/qaDatatablesContainer/QACertEventTestExmpDataTable/QACertEventTestExmpDataTable.js
@@ -480,17 +480,28 @@ const QACertEventTestExmpDataTable = ({
   const saveData = async () => {
     const userInput = extractUserInput(payload, ".modalUserInput");
 
+    // check if the monitoring system id and Component id are null or empty
+    if (!userInput.monitoringSystemId || !userInput.componentId) {
+      const errorMsgs = [
+        !userInput.monitoringSystemId && !userInput.componentId ? "Monitoring System ID and Component ID should not be empty" : !userInput.monitoringSystemId ? "Monitoring System ID should not be empty" : !userInput.componentId ? "Component ID should not be empty" : "",
+      ];
+      setErrorMsgs(errorMsgs);
+      return;
+    }
+
     try {
       const resp = await assertSelector.saveDataSwitch(userInput, dataTableName, locationSelectValue, selectedRow.id)
       if (successResponses.includes(resp.status)) {
         setUpdateTable(true)
         executeOnClose()
       } else {
-        const errorMsgs = Object.prototype.toString.call(resp) === "[object Array]" ? resp : [resp]
-        setErrorMsgs(errorMsgs)
+        const errorMsgs = Array.isArray(resp) ? resp : [resp];
+        setErrorMsgs(errorMsgs);
       }
     } catch (error) {
-      console.error(error)
+      console.error(error);
+      const errorMsgs = ["Error saving data"];
+      setErrorMsgs(errorMsgs);
     }
   };
 
@@ -502,6 +513,14 @@ const QACertEventTestExmpDataTable = ({
     } else if (userInput.stackPipeId) {
       userInput.stackPipeId = String(userInput.stackPipeId);
       userInput.unitId = null;
+    }
+    // check if the monitoring system id and Component id are null or empty
+    if (!userInput.monitoringSystemId || !userInput.componentId) {
+      const errorMsgs = [
+        !userInput.monitoringSystemId && !userInput.componentId ? "Monitoring System ID and Component ID should not be empty" : !userInput.monitoringSystemId ? "Monitoring System ID should not be empty" : !userInput.componentId ? "Component ID should not be empty" : ""
+      ];
+      setErrorMsgs(errorMsgs);
+      return;
     }
 
     try {
@@ -608,8 +627,8 @@ const QACertEventTestExmpDataTable = ({
                   create={createNewData}
                   setMainDropdownChange={setMainDropdownChange}
                   mainDropdownChange={mainDropdownChange}
-                  disableEditingForSelectedFields={selectedRow.isSubmitted || selectedRow.isSavedNotSubmitted}
-                  selectedEditingDisabledFields={ getEditingDisabledFields(dataTableName) }
+                  disableEditingForSelectedFields={selectedRow?.isSubmitted || selectedRow?.isSavedNotSubmitted}
+                  selectedEditingDisabledFields={getEditingDisabledFields(dataTableName)}
                 />
               </div>
             ) : (

--- a/src/utils/selectors/QACert/TestSummary.js
+++ b/src/utils/selectors/QACert/TestSummary.js
@@ -607,8 +607,8 @@ export const mapQaCertEventsDataToRows = (data, orisCode) => {
       col7: formatDateTime(el.conditionalBeginDate, el.conditionalBeginHour),
       col8: formatDateTime(el.completionTestDate, el.completionTestHour),
       col9: evalStatusContent(el.evalStatusCode, orisCode, el.id),
-      isSubmitted: el.isSubmitted,
-      isSavedNotSubmitted: el.isSavedNotSubmitted,
+      isSubmitted: el?.isSubmitted,
+      isSavedNotSubmitted: el?.isSavedNotSubmitted,
     };
     records.push(row);
   }
@@ -639,8 +639,8 @@ export const mapQaExtensionsExemptionsDataToRows = (data, orisCode) => {
       col9: el.extensionOrExemptionCode,
       col10: evalStatusContent(el.evalStatusCode, orisCode, el.id),
 
-      isSubmitted: el.isSubmitted,
-      isSavedNotSubmitted: el.isSavedNotSubmitted,
+      isSubmitted: el?.isSubmitted,
+      isSavedNotSubmitted: el?.isSavedNotSubmitted,
     });
   });
 


### PR DESCRIPTION
### **Ticket**
https://github.com/US-EPA-CAMD/easey-ui/issues/5786

### **Changes**
Fixed the bug for saving null values for monitoring system id and component id

![image](https://github.com/US-EPA-CAMD/easey-ecmps-ui/assets/169717416/fd5e3fee-5444-4970-98ba-d9d2a1b8a0c1)
![image](https://github.com/US-EPA-CAMD/easey-ecmps-ui/assets/169717416/b4a0cd08-e502-4508-b38c-e0c5f77edc94)
![image](https://github.com/US-EPA-CAMD/easey-ecmps-ui/assets/169717416/7cae03c8-0eef-4ce6-b65d-6049513bacd0)
![image](https://github.com/US-EPA-CAMD/easey-ecmps-ui/assets/169717416/32a3ee1a-3e6a-4643-a515-206720d8f78c)
