### PR TITLE
Fix/#6254 Updated last submitted in the screen

### DIFF
--- a/src/additional-functions/qa-dataTable-props.js
+++ b/src/additional-functions/qa-dataTable-props.js
@@ -1593,7 +1593,7 @@ export const qaHgInjectionDataProps = () => {
   };
 };
 
-export const qaCertEventsProps = selectedLocation => {
+export const qaCertEventsProps = (selectedLocation, user) => {
   const result = {
     dataTableName: 'QA Certification Event',
     payload: {
@@ -1672,10 +1672,15 @@ export const qaCertEventsProps = selectedLocation => {
     ...result.controlInputs,
   };
   //result.controlInputs[locId] = ["Unit/Stack Pipe ID", "input", "", ""];
+  
+  // Public view add "Last Submitted By" and "Last Submitted Date/Time"
+  if (!user) {
+    result.columns.push("Last Submitted By", "Last Submitted Date/Time")
+  }
   return result;
 };
 
-export const qaTestExemptionProps = selectedLocation => {
+export const qaTestExemptionProps = (selectedLocation, user) => {
   const result = {
     dataTableName: 'Test Extension Exemption',
     payload: {
@@ -1743,5 +1748,10 @@ export const qaTestExemptionProps = selectedLocation => {
     [locId]: ['Unit/Stack Pipe ID', 'input', '', ''],
     ...result.controlInputs,
   };
+
+  // Public view add "Last Submitted By" and "Last Submitted Date/Time"
+  if (!user) {
+    result.columns.push("Last Submitted By", "Last Submitted Date/Time")
+  }
   return result;
 };

--- a/src/components/HeaderInfo/HeaderInfo.js
+++ b/src/components/HeaderInfo/HeaderInfo.js
@@ -978,12 +978,15 @@ export const HeaderInfo = ({
         currentConfig.updateDate
       )}`;
     }
+
     // GLOBAL view
-    return `Last submitted by: ${selectedConfig.userId} ${formatDate(
-      selectedConfig.updateDate
-        ? selectedConfig.updateDate
-        : selectedConfig.addDate
-    )}`;
+    if (workspaceSection === MONITORING_PLAN_STORE_NAME) {
+      return `Last submitted by: ${selectedConfig.userId} ${formatDate(
+        selectedConfig.updateDate
+          ? selectedConfig.updateDate
+          : selectedConfig.addDate
+      )}`;
+    }
   };
 
   const resetEmissionsViewTable = () => {

--- a/src/components/QACertEventHeaderInfo/QACertEventHeaderInfo.js
+++ b/src/components/QACertEventHeaderInfo/QACertEventHeaderInfo.js
@@ -308,13 +308,6 @@ export const QACertEventHeaderInfo = ({
           true
         )}`;
       }
-      // GLOBAL view
-      return `Last submitted by: ${selectedConfig.userId} ${formatDate(
-        selectedConfig.updateDate
-          ? selectedConfig.updateDate
-          : selectedConfig.addDate,
-        true
-      )}`;
     }
   };
 

--- a/src/components/QACertTestSummaryHeaderInfo/QACertTestSummaryHeaderInfo.js
+++ b/src/components/QACertTestSummaryHeaderInfo/QACertTestSummaryHeaderInfo.js
@@ -382,13 +382,6 @@ export const QACertTestSummaryHeaderInfo = ({
           true
         )}`;
       }
-      // GLOBAL view
-      return `Last submitted by: ${selectedConfig.userId} ${formatDate(
-        selectedConfig.updateDate
-          ? selectedConfig.updateDate
-          : selectedConfig.addDate,
-        true
-      )}`;
     }
   };
 

--- a/src/components/qaDatatablesContainer/QACertEventTestExmpDataTable/QACertEventTestExmpDataTable.js
+++ b/src/components/qaDatatablesContainer/QACertEventTestExmpDataTable/QACertEventTestExmpDataTable.js
@@ -73,14 +73,14 @@ const QACertEventTestExmpDataTable = ({
   let props = {};
   switch (sectionSelect[1]) {
     case "QA Certification Event":
-      props = qaCertEventsProps(selectedLocation);
+      props = qaCertEventsProps(selectedLocation, user);
       break;
 
     case "Test Extension Exemption":
-      props = qaTestExemptionProps(selectedLocation);
+      props = qaTestExemptionProps(selectedLocation, user);
       break;
     default:
-      props = qaCertEventsProps(selectedLocation);
+      props = qaCertEventsProps(selectedLocation, user);
       break;
   }
 

--- a/src/utils/functions.js
+++ b/src/utils/functions.js
@@ -389,6 +389,19 @@ export const formatDateTime = (date, hour, mins) => {
   }
 };
 
+export const formatTimeStamp = (timeStamp) => {
+  if(!timeStamp){
+    return 
+  }
+  const date = new Date(timeStamp);
+  return `${date.getFullYear()}-${(date.getMonth() + 1)
+    .toString()
+    .padStart(2, "0")}-${date.getDate().toString().padStart(2, "0")} ${date
+    .getHours()
+    .toString()
+    .padStart(2, "0")}:${date.getMinutes().toString().padStart(2, "0")}`;
+};
+
 /**
  * Formats errored response into list of strings
  * @param {*} errorResp

--- a/src/utils/selectors/QACert/LinearitySummary.js
+++ b/src/utils/selectors/QACert/LinearitySummary.js
@@ -114,6 +114,11 @@ export const getQAColsByTestCode = (testCode, user = false) => {
     // console.log(`getQAColsByTestCode default case w/ testCode: ${testCode}`);
   }
 
+  // Public view add "Last Submitted By" and "Last Submitted Date/Time"
+  if (!user) {
+    cols.push("Last Submitted By", "Last Submitted Date/Time")
+  }
+
   return cols;
 };
 

--- a/src/utils/selectors/QACert/LinearitySummary.test.js
+++ b/src/utils/selectors/QACert/LinearitySummary.test.js
@@ -12,6 +12,8 @@ describe("testing getLinearitySummary data selectors", () => {
       "Test Number",
       "Test Reason Code",
       "End Date/Time",
+      "Last Submitted By",
+      "Last Submitted Date/Time"
       // "End Hour",
       // "End Minute",
     ];
@@ -26,6 +28,8 @@ describe("testing getLinearitySummary data selectors", () => {
       "Test Reason Code",
       "Test Result Code",
       "End Date/Time",
+      "Last Submitted By",
+      "Last Submitted Date/Time"
       // "End Hour",
       // "End Minute",
     ];
@@ -47,6 +51,8 @@ describe("testing getLinearitySummary data selectors", () => {
       "Test Result Code",
       "Year",
       "Quarter",
+      "Last Submitted By",
+      "Last Submitted Date/Time"
     ];
 
     expect(fs.getQAColsByTestCode("FLC")).toEqual(FLCCols);
@@ -58,6 +64,8 @@ describe("testing getLinearitySummary data selectors", () => {
       "Monitoring System ID",
       "Test Number",
       "End Date/Time",
+      "Last Submitted By",
+      "Last Submitted Date/Time"
       // "End Hour",
       // "End Minute",
     ];
@@ -70,6 +78,8 @@ describe("testing getLinearitySummary data selectors", () => {
       "Monitoring System ID",
       "Test Number",
       "End Date/Time",
+      "Last Submitted By",
+      "Last Submitted Date/Time"
       //"End Hour",
     ];
 
@@ -83,6 +93,8 @@ describe("testing getLinearitySummary data selectors", () => {
       "Test Reason Code",
       "Test Result Code",
       "End Date/Time",
+      "Last Submitted By",
+      "Last Submitted Date/Time"
       //"End Hour",
     ];
 
@@ -96,6 +108,8 @@ describe("testing getLinearitySummary data selectors", () => {
       "Test Reason Code",
       "Test Result Code",
       "End Date/Time",
+      "Last Submitted By",
+      "Last Submitted Date/Time"
       // "End Hour",
       // "End Minute",
     ];
@@ -108,6 +122,8 @@ describe("testing getLinearitySummary data selectors", () => {
       "Test Number",
       "Test Reason Code",
       "End Date/Time",
+      "Last Submitted By",
+      "Last Submitted Date/Time"
       // "End Hour",
       // "End Minute",
     ];
@@ -123,6 +139,8 @@ describe("testing getLinearitySummary data selectors", () => {
       "Test Reason Code",
       "Test Result Code",
       "End Date/Time",
+      "Last Submitted By",
+      "Last Submitted Date/Time"
       // "End Hour",
       // "End Minute",
     ];
@@ -137,6 +155,8 @@ describe("testing getLinearitySummary data selectors", () => {
       "Test Reason Code",
       "Test Result Code",
       "End Date/Time",
+      "Last Submitted By",
+      "Last Submitted Date/Time"
       // "End Hour",
       // "End Minute",
     ];

--- a/src/utils/selectors/QACert/TestSummary.js
+++ b/src/utils/selectors/QACert/TestSummary.js
@@ -1,5 +1,5 @@
 import { evalStatusContent } from "../../../additional-functions/evaluate-configs";
-import { formatDateTime } from '../../../utils/functions'
+import { formatDateTime, formatTimeStamp } from '../../../utils/functions';
 
 export const getTestSummary = (data, colTitles, orisCode) => {
   const records = [];
@@ -47,6 +47,9 @@ export const getTestSummary = (data, colTitles, orisCode) => {
           case "Eval Status":
             colValue = evalStatusContent(curData.evalStatusCode, orisCode, id);
             break;
+            case "Last Submitted Date/Time":
+              colValue = formatTimeStamp(curData.updateDate ?? curData.addDate);
+              break;
           default:
         }
         columnDef[colKey] = colValue;
@@ -78,6 +81,7 @@ const colTitleToDtoKeyMap = {
   "Injection Protocol Code": "injectionProtocolCode",
   "Test Comment": "testComment",
   "Eval Status": "evalStatusCode",
+  "Last Submitted By": "userId"
 };
 
 const mapTestSummaryColTitleToDTOKey = (columnTitle) => {
@@ -606,7 +610,9 @@ export const mapQaCertEventsDataToRows = (data, orisCode) => {
       col6: isNaN(el.requiredTestCode) ? el.requiredTestCode : Number(el.requiredTestCode),
       col7: formatDateTime(el.conditionalBeginDate, el.conditionalBeginHour),
       col8: formatDateTime(el.completionTestDate, el.completionTestHour),
-      col9: evalStatusContent(el.evalStatusCode, orisCode, el.id),
+      col9: el.userId,
+      col10: formatTimeStamp(el.updateDate ?? el.addDate),
+      col11: evalStatusContent(el.evalStatusCode, orisCode, el.id),
       isSubmitted: el?.isSubmitted,
       isSavedNotSubmitted: el?.isSavedNotSubmitted,
     };
@@ -637,7 +643,9 @@ export const mapQaExtensionsExemptionsDataToRows = (data, orisCode) => {
       col7: el.spanScaleCode,
       col8: el.fuelCode,
       col9: el.extensionOrExemptionCode,
-      col10: evalStatusContent(el.evalStatusCode, orisCode, el.id),
+      col10: el.userId,
+      col11: formatTimeStamp(el.updateDate ?? el.addDate),
+      col12: evalStatusContent(el.evalStatusCode, orisCode, el.id),
 
       isSubmitted: el?.isSubmitted,
       isSavedNotSubmitted: el?.isSavedNotSubmitted,


### PR DESCRIPTION
## Ticket
[QA & Emissions screens: Incorrect "Last submitted by" data in public view](https://github.com/US-EPA-CAMD/easey-ui/issues/6254)

## Changes

- Remove Last submitted by from QA header and  Emission Header
- Added Last Submitted By and Last Submitted Date/Time columns in QA Test Data and Cert Events, Extensions & Exemptions screens