### PR TITLE
Fix/6366 disallow checkout

### DIFF
--- a/src/additional-functions/checkout.js
+++ b/src/additional-functions/checkout.js
@@ -22,7 +22,7 @@ export const checkoutAPI = (
       });
   } else {
     return mpApi
-      .postCheckoutMonitoringPlanConfiguration(monitorPlanId, user.userId)
+      .postCheckoutMonitoringPlanConfiguration(monitorPlanId)
       .then((res) => {
         if (setCheckout !== undefined) {
           setCheckout(true, configID, MONITORING_PLAN_STORE_NAME);

--- a/src/additional-functions/checkout.test.js
+++ b/src/additional-functions/checkout.test.js
@@ -58,8 +58,7 @@ describe("checkoutAPI", () => {
     await checkoutAPI(direction, configID, monitorPlanId, mockSetCheckout);
 
     expect(mockPostCheckoutMonitoringPlanConfiguration).toHaveBeenCalledWith(
-      monitorPlanId,
-      "123"
+      monitorPlanId
     );
     expect(mockSetCheckout).toHaveBeenCalledWith(
       true,
@@ -107,8 +106,7 @@ describe("checkoutAPI", () => {
     await checkoutAPI(direction, configID, monitorPlanId, mockSetCheckout);
 
     expect(mockPostCheckoutMonitoringPlanConfiguration).toHaveBeenCalledWith(
-      monitorPlanId,
-      "123"
+      monitorPlanId
     );
     expect(mockSetCheckout).toHaveBeenCalledWith(
       true,

--- a/src/components/datatablesContainer/DataTableConfigurations/DataTableConfigurations.js
+++ b/src/components/datatablesContainer/DataTableConfigurations/DataTableConfigurations.js
@@ -84,7 +84,7 @@ export const DataTableConfigurations = ({
     if (!checkIn) {
       if (checkout) {
         mpApi
-          .postCheckoutMonitoringPlanConfiguration(config.col3, user.userId)
+          .postCheckoutMonitoringPlanConfiguration(config.col3)
           .then((res) => {
             setSelectedConfig([data, selectedConfigData, checkout]);
 
@@ -126,7 +126,7 @@ export const DataTableConfigurations = ({
   }, [selectedConfig]);
 
   useEffect(() => {
-    // cannot use .then() to call setDataLoaded with dispatch() in react 18 
+    // cannot use .then() to call setDataLoaded with dispatch() in react 18
     const callbackFunction = () => {
       setDataLoaded(true);
       dispatch(loadMonitoringPlansArray(data.col2));
@@ -143,7 +143,6 @@ export const DataTableConfigurations = ({
         ...selectedMP,
         monitoringPlans[monitoringPlans.length - 1],
       ]);
-  
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [monitoringPlans]);
@@ -155,7 +154,7 @@ export const DataTableConfigurations = ({
         for (const x of monitoringPlans) {
           if (x[0] === data.col2) {
             index = x[1];
-          
+
             return fs.getConfigurationNames(index);
           }
         }
@@ -194,6 +193,5 @@ export const DataTableConfigurations = ({
     </div>
   );
 };
-
 
 export default DataTableConfigurations;

--- a/src/utils/api/monitoringPlansApi.js
+++ b/src/utils/api/monitoringPlansApi.js
@@ -131,25 +131,19 @@ export const getMonitoringAnalyzerRanges = async (locId, componentRecordId) => {
 
 export const postCheckoutMonitoringPlanConfiguration = async (
   id,
-  handleError = true
+  shouldHandleError = true
 ) => {
   const url = getApiUrl(`/check-outs/plans/${id}`, true);
-  if (handleError) {
-    try {
-      return (
-        await secureAxios({
-          method: "POST",
-          url: url,
-        })
-      ).data;
-    } catch (error) {
-      return handleError(error);
-    }
-  } else {
-    return await secureAxios({
-      method: "POST",
-      url: url,
-    });
+  try {
+    return (
+      await secureAxios({
+        method: "POST",
+        url: url,
+      })
+    ).data;
+  } catch (error) {
+    if (!shouldHandleError) throw error;
+    return handleError(error);
   }
 };
 


### PR DESCRIPTION
## Related Issues

- [#6366](https://github.com/US-EPA-CAMD/easey-ui/issues/6366)

## Main Changes

- Fixed the `postCheckoutMonitoringPlanConfiguration`: The `handleError` function was being shadowed by a parameter, so errors would not be handled correctly.
- Fixed some calls to the same function that were supplying incorrect arguments.