### PR TITLE
Feature/#6369 display message for responsibility free users

### DIFF
--- a/src/components/AboutHome/AboutHome.js
+++ b/src/components/AboutHome/AboutHome.js
@@ -11,6 +11,7 @@ import axios from "axios";
 import { handleResponse, handleError } from "../../utils/api/apiUtils";
 import "./AboutHome.scss";
 import {getLoginState} from "../../utils/api/easeyAuthApi";
+import { displayAppWarning } from "../../additional-functions/app-error";
 
 const getContent = async (path) => {
   const url = `${config.services.content.uri}${path}`;
@@ -28,6 +29,8 @@ const AboutHome = ({ user, setCurrentLink }) => {
   const [whatIsNewContent, setWhatIsNewContent] = useState();
   const [monitorPlanContent, setMonitorPlanContent] = useState();
   const [qaCertificationContent, setQACertificationContent] = useState();
+
+  const [warningMessage, setWarningMessage] = useState(null);
 
   useEffect(() => {
     document.title = "ECMPS Home";
@@ -48,6 +51,21 @@ const AboutHome = ({ user, setCurrentLink }) => {
       setQACertificationContent(resp.data)
     );
   }, []);
+
+  //Display login warnings for the login initial authorizer user with no responsibilities.
+  useEffect(() => {
+    //get the current user
+    const cdxUser = JSON.parse(localStorage.getItem("ecmps_user"));
+
+    //check if the user has initial authorizer role with no responsibilities
+    if (cdxUser?.roles?.includes(config.app.initialAuthorizerRole) &&  JSON.stringify(cdxUser?.facilities) === '{}')
+    {
+      //display the warning message on the home page
+      const warningMessage = 'You have no facilities for which you are responsible. Please login to CBS to review and add facilities for which you are responsible.';
+      displayAppWarning(warningMessage);
+      setWarningMessage(warningMessage);
+    }
+  }, [user]);
 
   const handleRouteChange = (event, url) => {
     setCurrentLink(url);

--- a/src/components/AboutHome/AboutHome.js
+++ b/src/components/AboutHome/AboutHome.js
@@ -30,8 +30,6 @@ const AboutHome = ({ user, setCurrentLink }) => {
   const [monitorPlanContent, setMonitorPlanContent] = useState();
   const [qaCertificationContent, setQACertificationContent] = useState();
 
-  const [warningMessage, setWarningMessage] = useState(null);
-
   useEffect(() => {
     document.title = "ECMPS Home";
 
@@ -58,12 +56,11 @@ const AboutHome = ({ user, setCurrentLink }) => {
     const cdxUser = JSON.parse(localStorage.getItem("ecmps_user"));
 
     //check if the user has initial authorizer role with no responsibilities
-    if (cdxUser?.roles?.includes(config.app.initialAuthorizerRole) &&  JSON.stringify(cdxUser?.facilities) === '{}')
+    if (cdxUser?.roles?.includes(config.app.initialAuthorizerRole) && Object.keys(cdxUser?.facilities || {}).length === 0)
     {
       //display the warning message on the home page
       const warningMessage = 'You have no facilities for which you are responsible. Please login to CBS to review and add facilities for which you are responsible.';
       displayAppWarning(warningMessage);
-      setWarningMessage(warningMessage);
     }
   }, [user]);
 


### PR DESCRIPTION
## Pull Request

```

- Added related logic in component AboutHome to display warning message on the ECMPS home page, to remind user with IA role and no responsibility assigned about login to CBS to review and add facilities.

```
