### PR TITLE
Feature/5995 configuration manager

### DIFF
--- a/src/components/ConfigurationManagement/ConfigurationManagement.js
+++ b/src/components/ConfigurationManagement/ConfigurationManagement.js
@@ -73,6 +73,7 @@ const initialFormState = {
   stackPipes: [],
   unitStackConfigs: [],
 };
+const MONITOR_PLAN_SCHEMA_VERSION = "1.0.0";
 const STACK_PIPE_ID_HINT =
   "Enter an ID that begins with CS, CP, MS, or MP and is followed by 1 to 4 alphanumeric characters or dash (-) characters";
 const STACK_PIPE_ID_PATTERN = "^[MC][SP][a-zA-Z0-9\\-]{1,4}$";
@@ -630,7 +631,6 @@ export const ConfigurationManagement = ({
   const [formState, formDispatch] = useReducer(formReducer, initialFormState);
   const [modalErrorMsgs, setModalErrorMsgs] = useState([]);
   const [modalVisible, setModalVisible] = useState(false);
-  const monitorPlansPayload = useRef(null);
   const [monitoringPlansStatus, setMonitoringPlansStatus] = useState(
     dataStatus.IDLE
   );
@@ -684,6 +684,8 @@ export const ConfigurationManagement = ({
       (loc) => loc.checkedOutBy !== user.userId
     );
 
+  const changedPlansCount = Object.values(changeSummary).flat().length;
+
   /* HANDLERS */
 
   const checkForDuplicateStackPipeIds = () => {
@@ -710,20 +712,11 @@ export const ConfigurationManagement = ({
 
   const createChangeSummary = async () => {
     setChangeSummaryStatus(dataStatus.PENDING);
-    const newMonitorPlansPayload = mapFormStateToPayload();
-    monitorPlansPayload.current = newMonitorPlansPayload;
 
     try {
       const [bulkResult, ...singleUnitResults] = await Promise.all([
-        importMP(newMonitorPlansPayload, true),
-        ...formState.units
-          .filter((u) => u.isToggled)
-          .map((u) =>
-            createSingleUnitMP(
-              { unitId: u.unitId, facilityId: selectedFacility },
-              true
-            )
-          ),
+        sendConfigurationsPayload(true),
+        ...sendSingleUnitPayloads(true),
       ]);
 
       setModalErrorMsgs(
@@ -829,8 +822,10 @@ export const ConfigurationManagement = ({
   const handleConfirmSave = async () => {
     setSaveStatus(dataStatus.PENDING);
     try {
-      if (monitorPlansPayload.current)
-        await importMP(monitorPlansPayload.current, false);
+      await Promise.all([
+        sendConfigurationsPayload(false),
+        ...sendSingleUnitPayloads(false),
+      ]);
       setSaveStatus(dataStatus.SUCCESS);
       [
         setMonitoringPlansStatus,
@@ -895,7 +890,7 @@ export const ConfigurationManagement = ({
     });
   };
 
-  const mapFormStateToPayload = () => ({
+  const mapFormStateToConfigurationsPayload = () => ({
     monitoringPlanCommentData: [],
     orisCode: userFacilities.find(
       (f) => f.facilityRecordId === selectedFacility
@@ -925,6 +920,12 @@ export const ConfigurationManagement = ({
           ...unusedMonitoringLocationDataFields(),
         }))
       ),
+    version: MONITOR_PLAN_SCHEMA_VERSION,
+  });
+
+  const mapFormStateToSingleUnitPayload = (unit) => ({
+    unitId: unit.unitId,
+    orisCode: selectedOrisCode,
   });
 
   const removeStackPipe = (rowId) => {
@@ -949,6 +950,22 @@ export const ConfigurationManagement = ({
 
   const revertUnitStackConfig = (rowId) => {
     formDispatch({ type: "REVERT_UNIT_STACK_CONFIG", payload: rowId });
+  };
+
+  const sendConfigurationsPayload = (draft) => {
+    return importMP(mapFormStateToConfigurationsPayload(), {
+      draft,
+      shouldHandleError: false,
+    });
+  };
+
+  const sendSingleUnitPayloads = (draft) => {
+    return formState.units
+      .filter((u) => u.isToggled)
+      .map(mapFormStateToSingleUnitPayload)
+      .map((payload) =>
+        createSingleUnitMP(payload, { draft, shouldHandleError: false })
+      );
   };
 
   const setStackPipeActiveDate = (rowId, activeDate) => {
@@ -1507,7 +1524,8 @@ export const ConfigurationManagement = ({
                         saveStatus
                       ) &&
                       (!canCheckOut || isCheckedOutByUser) &&
-                      !modalErrorMsgs.length
+                      !modalErrorMsgs.length &&
+                      changedPlansCount > 0
                     }
                     title="Change Summary"
                   >
@@ -1516,14 +1534,22 @@ export const ConfigurationManagement = ({
                       label="summary of configuration changes"
                       status={changeSummaryStatus}
                     >
-                      <SummarySectionPlan
-                        plans={changeSummary.newPlans}
-                        title="New Plans"
-                      />
-                      <SummarySectionPlan
-                        plans={changeSummary.endedPlans}
-                        title="Ended Plans"
-                      />
+                      {changedPlansCount === 0 ? (
+                        <Alert noIcon slim type="info" headingLevel="h3">
+                          There are no configuration changes to apply.
+                        </Alert>
+                      ) : (
+                        <>
+                          <SummarySectionPlan
+                            plans={changeSummary.newPlans}
+                            title="New Plans"
+                          />
+                          <SummarySectionPlan
+                            plans={changeSummary.endedPlans}
+                            title="Ended Plans"
+                          />
+                        </>
+                      )}
                     </StatusContent>
                     <SaveStatusAlert status={saveStatus} />
                   </Modal>

--- a/src/components/ConfigurationManagement/ConfigurationManagement.js
+++ b/src/components/ConfigurationManagement/ConfigurationManagement.js
@@ -24,7 +24,6 @@ import React, {
   useEffect,
   useMemo,
   useReducer,
-  useRef,
   useState,
 } from "react";
 import DataTable from "react-data-table-component";
@@ -61,6 +60,8 @@ import "./ConfigurationManagement.scss";
 const DEFAULT_DROPDOWN_TEXT = "-- Select a value --";
 const errorMessages = {
   DUPLICATE_STACKPIPE_IDS: "Stack/Pipe IDs must be unique.",
+  DUPLICATE_UNIT_STACK_CONFIGS:
+    "Unit/Stack Configurations with the same Unit and Stack/Pipe cannot have the same begin date.",
   EDITS_PENDING: "Please complete any pending edits before continuing.",
   NOT_CHECKED_OUT: "You must check out the facility before saving.",
 };
@@ -694,6 +695,15 @@ export const ConfigurationManagement = ({
     }
   };
 
+  const checkForDuplicateUnitStackConfigs = () => {
+    const unitStackConfigs = formState.unitStackConfigs
+      .map((usc) => [usc.unitId, usc.stackPipeId, usc.beginDate])
+      .map(JSON.stringify);
+    if (new Set(unitStackConfigs).size !== unitStackConfigs.length) {
+      return true;
+    }
+  };
+
   const checkForPendingEdits = () => {
     return Object.values(formState)
       .flat()
@@ -855,8 +865,13 @@ export const ConfigurationManagement = ({
       newErrorMsgs.push(errorMessages.NOT_CHECKED_OUT);
     }
 
-    if (checkForDuplicateStackPipeIds())
+    if (checkForDuplicateStackPipeIds()) {
       newErrorMsgs.push(errorMessages.DUPLICATE_STACKPIPE_IDS);
+    }
+
+    if (checkForDuplicateUnitStackConfigs()) {
+      newErrorMsgs.push(errorMessages.DUPLICATE_UNIT_STACK_CONFIGS);
+    }
 
     setErrorMsgs(newErrorMsgs);
     if (newErrorMsgs.length) return;

--- a/src/components/ConfigurationManagement/ConfigurationManagement.js
+++ b/src/components/ConfigurationManagement/ConfigurationManagement.js
@@ -392,7 +392,8 @@ function unusedMonitoringLocationDataFields() {
 
 const actionCellToggle = (onToggle) => {
   return (row) =>
-    row.associatedMonitorPlanIds.length === 0 ? (
+    row.associatedMonitorPlanIds.length === 0 &&
+    ["OPR", "FUT"].includes(row.opStatusCd) ? (
       <Button
         aria-label={
           row.isToggled
@@ -484,51 +485,49 @@ const dateCell = ({
   };
 };
 
-const PlanSummary = ({ plan }) => {
-  return (
-    <>
-      <h4>{plan.name}</h4>
-      <GridContainer>
-        <Grid row>
-          <Grid col={4} className="text-bold">
-            Begin Reporting Period:
-          </Grid>
-          <Grid col="auto">{plan.beginReportPeriodDescription}</Grid>
+const PlanSummary = ({ plan }) => (
+  <>
+    <h4>{plan.name}</h4>
+    <GridContainer>
+      <Grid row>
+        <Grid col={4} className="text-bold">
+          Begin Reporting Period:
         </Grid>
-        <Grid row>
-          <Grid col={4} className="text-bold">
-            End Reporting Period:
-          </Grid>
-          <Grid col="auto">{plan.endReportPeriodDescription ?? "N/A"}</Grid>
+        <Grid col="auto">{plan.beginReportPeriodDescription}</Grid>
+      </Grid>
+      <Grid row>
+        <Grid col={4} className="text-bold">
+          End Reporting Period:
         </Grid>
-      </GridContainer>
-      <h5 className="display-block text-primary">Plan Reporting Frequencies</h5>
-      <GridContainer>
-        {plan.reportingFrequencies.map((rf) => (
-          <Fragment key={rf.id}>
-            <Grid row>
-              <Grid col={4} className="text-bold">
-                Reporting Period Range:
-              </Grid>
-              <Grid col="auto">
-                {rf.beginReportPeriodDescription} -{" "}
-                {rf.endReportPeriodDescription ?? "Current"}
-              </Grid>
+        <Grid col="auto">{plan.endReportPeriodDescription ?? "N/A"}</Grid>
+      </Grid>
+    </GridContainer>
+    <h5 className="display-block text-primary">Plan Reporting Frequencies</h5>
+    <GridContainer>
+      {plan.reportingFrequencies.map((rf) => (
+        <Fragment key={rf.id}>
+          <Grid row>
+            <Grid col={4} className="text-bold">
+              Reporting Period Range:
             </Grid>
-            <Grid row>
-              <Grid col={4} className="text-bold">
-                Reporting Frequency:
-              </Grid>
-              <Grid col="auto">
-                {rf.reportingFrequencyCode === "Q" ? "Annual" : "Ozone Season"}
-              </Grid>
+            <Grid col="auto">
+              {rf.beginReportPeriodDescription} -{" "}
+              {rf.endReportPeriodDescription ?? "Current"}
             </Grid>
-          </Fragment>
-        ))}
-      </GridContainer>
-    </>
-  );
-};
+          </Grid>
+          <Grid row>
+            <Grid col={4} className="text-bold">
+              Reporting Frequency:
+            </Grid>
+            <Grid col="auto">
+              {rf.reportFrequencyCode === "Q" ? "Annual" : "Ozone Season"}
+            </Grid>
+          </Grid>
+        </Fragment>
+      ))}
+    </GridContainer>
+  </>
+);
 
 const SaveStatusAlert = ({ status }) => (
   <>
@@ -1100,11 +1099,13 @@ export const ConfigurationManagement = ({
         getUnitsByOrisCode(selectedOrisCode).then((res) => {
           setUnitsStatus(dataStatus.SUCCESS);
           initializeToggleableFormState(
-            res.data.map((d) => ({
-              ...d,
-              beginDate: d.beginDate ? d.beginDate.split("T")[0] : null,
-              endDate: d.endDate ? d.endDate.split("T")[0] : null,
-            })),
+            res.data
+              .filter((d) => d.opStatusCd !== "CAN") // Filter out canceled units
+              .map((d) => ({
+                ...d,
+                beginDate: d.beginDate ? d.beginDate.split("T")[0] : null,
+                endDate: d.endDate ? d.endDate.split("T")[0] : null,
+              })),
             "SET_UNITS"
           );
         });

--- a/src/components/DataTableRender/DataTableRender.js
+++ b/src/components/DataTableRender/DataTableRender.js
@@ -306,8 +306,7 @@ export const DataTableRender = ({
 
                     {workspaceSection !== EXPORT_STORE_NAME &&
                     isAnyLocationCheckedOutByUser() === false &&
-                    isLocationCheckedOut(row["facId"]) === false &&
-                    row["col2"] === "Active" ? (
+                    isLocationCheckedOut(row["facId"]) === false ? (
                       <>
                         <span className="margin-x-1">|</span>
                         <Button
@@ -586,7 +585,11 @@ export const DataTableRender = ({
               {...ariaLabelProp}
             />{" "}
             <div className={`${headerStyling}`}>
-              {addBtn && checkout && user && allowToCreateNewData && !nonEditable ? (
+              {addBtn &&
+              checkout &&
+              user &&
+              allowToCreateNewData &&
+              !nonEditable ? (
                 <div className="padding-y-1">
                   <Button
                     type="button"
@@ -632,7 +635,11 @@ export const DataTableRender = ({
               )}
             </div>
             <div className={`${headerStyling}`}>
-              {addBtn && checkout && user && allowToCreateNewData && !nonEditable ? (
+              {addBtn &&
+              checkout &&
+              user &&
+              allowToCreateNewData &&
+              !nonEditable ? (
                 <h2 className="padding-0 page-subheader">
                   <div className="padding-y-1">
                     <Button

--- a/src/components/ErrorSuppression/AddErrorSuppressionModal/esFunctions.js
+++ b/src/components/ErrorSuppression/AddErrorSuppressionModal/esFunctions.js
@@ -1,6 +1,7 @@
 import { getMdmData as getMatchData } from "../../../utils/api/errorSuppressionApi";
 import { getMonitoringPlans } from "../../../utils/api/monitoringPlansApi";
 import { getQATestSummary } from "../../../utils/api/qaCertificationsAPI";
+import { DatabaseContext } from "../../../utils/constants/databaseContext";
 
 // The mdm api returns a data that looks different for each Data Type Code.
 // The below function maps the correct description and code field for a
@@ -113,7 +114,7 @@ export const createMatchTypeDropdownLists = async (
     if (!orisCode) return [];
 
     try {
-      const { data } = await getMonitoringPlans([orisCode], [], true);
+      const { data } = await getMonitoringPlans([orisCode], [], DatabaseContext.WORKSPACE);
       return processPromiseData(data);
     } catch (e) {
       console.error(e);

--- a/src/components/EvaluateAndSubmit/EvaluateRefresh.js
+++ b/src/components/EvaluateAndSubmit/EvaluateRefresh.js
@@ -11,10 +11,10 @@ export const EvaluateRefresh = ({
   
   const refreshPage = async () => {
     if (storedFilters.current !== null) {
-      for (const [key, value] of Object.entries(dataList)) {
+      for (const value of dataList) {
         let data;
 
-        const { ref, rowId, call } = value;
+        const { ref, rowId, call, type: key } = value;
 
         if (key !== "MP") {
           //Filter emissions by quarter as well

--- a/src/components/EvaluateAndSubmit/EvaluateRefresh.test.js
+++ b/src/components/EvaluateAndSubmit/EvaluateRefresh.test.js
@@ -12,10 +12,9 @@ describe("EvaluateRefresh Component", () => {
     await act(async () => {
       render(
         <EvaluateRefresh
-          dataList={{
-            monPlan: {
+          dataList={[
+            {
               ref: { current: [{ monPlanId: "test", evalStatusCode: "PASS" }] },
-              state: jest.fn(),
               call: callFunc.mockResolvedValue({
                 data: [
                   {
@@ -25,8 +24,10 @@ describe("EvaluateRefresh Component", () => {
                 ],
               }),
               rowId: "monPlanId",
+              name: "Monitoring Plan",
+              type: "MP",
             },
-          }}
+          ]}
           storedFilters={{
             current: {
               orisCodes: [],
@@ -42,8 +43,8 @@ describe("EvaluateRefresh Component", () => {
 
   it("Fast forward timer and expect mock calls to have been made", async () => {
     await act(async () => {
-       jest.advanceTimersByTime(config.app.refreshEvalStatusRate);
+      jest.advanceTimersByTime(config.app.refreshEvalStatusRate);
     });
-    expect(callFunc).toHaveBeenCalled();;
+    expect(callFunc).toHaveBeenCalled();
   });
 });

--- a/src/components/HeaderInfo/HeaderInfo.js
+++ b/src/components/HeaderInfo/HeaderInfo.js
@@ -14,6 +14,7 @@ import config from "../../config";
 
 import { checkoutAPI } from "../../additional-functions/checkout";
 import * as mpApi from "../../utils/api/monitoringPlansApi";
+import { DatabaseContext } from "../../utils/constants/databaseContext";
 import * as emApi from "../../utils/api/emissionsApi";
 import {
   EMISSIONS_STORE_NAME,
@@ -819,7 +820,7 @@ export const HeaderInfo = ({
 
   const showRevert = (status) => {
     return (
-      (checkedOutByUser || !selectedConfig.active) &&
+      checkedOutByUser &&
       (status === "PASS" ||
         status === "INFO" ||
         status === "ERR" ||
@@ -856,10 +857,9 @@ export const HeaderInfo = ({
       const res = await mpApi.getMonitoringPlans(
         orisCode,
         selectedConfig.id,
-        true
+        DatabaseContext.WORKSPACE,
       );
       if (res.data.length === 0) {
-        await mpApi.deleteCheckInMonitoringPlanConfiguration(selectedConfig.id);
         removeTab(currentTabIndex); // Newly created plans are deleted rather than reverted, so remove it from the tabs
       } else {
         dispatch(loadSingleMonitoringPlanSuccess(orisCode, res.data[0]));
@@ -1261,7 +1261,7 @@ export const HeaderInfo = ({
                 >
                   Export Data
                 </Button>
-                {user && checkedOutByUser && (
+                {user && checkedOutByUser && selectedConfig.active && (
                   <Button
                     type="button"
                     className="margin-y-1"
@@ -1304,7 +1304,6 @@ export const HeaderInfo = ({
                     </Button>
                   ) : !lockedFacility &&
                     !userHasCheckout &&
-                    selectedConfig.active &&
                     checkedOutConfigs
                       .map((location) => location["monPlanId"])
                       .indexOf(selectedConfig.id) === -1 ? (

--- a/src/components/ReportGenerator/Report/Report.js
+++ b/src/components/ReportGenerator/Report/Report.js
@@ -108,7 +108,7 @@ export const Report = ({ reportData, dataLoaded, paramsObject }) => {
     function findGroupByName(groups, name) {
       return groups.find((group) => group.name === name);
     }
-    
+
     function findItemByCode(items, code) {
       return items.find((item) => item.code === code);
     }
@@ -259,3 +259,4 @@ export const Report = ({ reportData, dataLoaded, paramsObject }) => {
 };
 
 export default Report;
+

--- a/src/components/datatablesContainer/DataTableConfigurations/DataTableConfigurations.js
+++ b/src/components/datatablesContainer/DataTableConfigurations/DataTableConfigurations.js
@@ -140,8 +140,7 @@ export const DataTableConfigurations = ({
     };
     // Call the callback function
     callbackFunction();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dispatch]);
+  }, [dispatch, orisCode]);
 
   useEffect(() => {
     if (dataLoaded) {

--- a/src/components/export/ExportTab/ExportTab.js
+++ b/src/components/export/ExportTab/ExportTab.js
@@ -130,7 +130,7 @@ export const ExportTab = ({
   useEffect(() => {
     const fetchTableData = async () => {
       const promises = dataTypes.map((dt) =>
-        dt.dataFetch([orisCode], [selectedConfigId], [reportingPeriod])
+        dt.dataFetch([orisCode], [selectedConfigId], dt.reportCode === 'MPP' ? null : [reportingPeriod])
       );
       const responses = await Promise.all(promises);
 

--- a/src/config.js
+++ b/src/config.js
@@ -187,6 +187,8 @@ if (config.app.enableDebug) {
 
 if (config.app.env === "production") {
   log.setLevel(log.levels.ERROR);
+} else {
+  log.setLevel(log.levels.TRACE);
 }
 
 export default config;

--- a/src/utils/api/apiUtils.js
+++ b/src/utils/api/apiUtils.js
@@ -77,8 +77,8 @@ export async function logServerError(errorId, message, stackTrace) {
       data: {
         errorId,
         message,
-        stackTrace
-      }
+        stackTrace,
+      },
     });
   } catch (error) {
     handleError(error);

--- a/src/utils/api/monitoringPlansApi.js
+++ b/src/utils/api/monitoringPlansApi.js
@@ -1192,7 +1192,10 @@ export const getMonitoringPlanComments = async (monPlanId) => {
     .catch(handleError);
 };
 
-export const importMP = async (payload, draft) => {
+export const importMP = async (
+  payload,
+  { draft = false, shouldHandleError = true } = {}
+) => {
   let url = getApiUrl(`/plans/import`);
   if (draft) {
     url = url + "?draft=true";
@@ -1206,11 +1209,15 @@ export const importMP = async (payload, draft) => {
       })
     );
   } catch (error) {
+    if (!shouldHandleError) throw error;
     return handleImportError(error);
   }
 };
 
-export const createSingleUnitMP = async (payload, draft) => {
+export const createSingleUnitMP = async (
+  payload,
+  { draft = false, shouldHandleError = true } = {}
+) => {
   let url = getApiUrl(`/plans/single-unit`);
   if (draft) {
     url = url + "?draft=true";
@@ -1224,6 +1231,7 @@ export const createSingleUnitMP = async (payload, draft) => {
       })
     );
   } catch (error) {
+    if (!shouldHandleError) throw error;
     return handleImportError(error);
   }
 };

--- a/src/utils/api/monitoringPlansApi.js
+++ b/src/utils/api/monitoringPlansApi.js
@@ -7,14 +7,19 @@ import download from "downloadjs";
 import axios from "axios";
 
 export const getApiUrl = (path, context) => {
-  let url;
-  if (context === DatabaseContext.OFFICIAL) {
-    url = config.services.monitorPlans.uri;
-  } else if (context === DatabaseContext.WORKSPACE || window.location.href.includes("/workspace")) {
-    url = `${config.services.monitorPlans.uri}/workspace`;
+  const base = config.services.monitorPlans.uri;
+  switch (context) {
+    case DatabaseContext.OFFICIAL:
+      return `${base}${path}`;
+    case DatabaseContext.WORKSPACE:
+      return `${base}/workspace${path}`;
+    default:
+      if (window.location.href.includes("/workspace")) {
+        return `${base}/workspace${path}`;
+      } else {
+        return `${base}${path}`;
+      }
   }
-
-  return `${url}${path}`;
 };
 
 export const getMonitoringPlanById = async (id) => {
@@ -32,7 +37,7 @@ export const getMonitoringPlanById = async (id) => {
 export const getMonitoringPlans = async (
   orisCodes,
   monPlanIds = [],
-  context = null,
+  context = null
 ) => {
   let queryString = "";
 

--- a/src/utils/api/monitoringPlansApi.js
+++ b/src/utils/api/monitoringPlansApi.js
@@ -1,15 +1,17 @@
 import { handleResponse, handleError, handleImportError } from "./apiUtils";
 import config from "../../config";
+import { DatabaseContext } from "../constants/databaseContext";
 import { secureAxios } from "./easeyAuthApi";
 import { getFacilityById } from "./facilityApi";
 import download from "downloadjs";
 import axios from "axios";
 
-export const getApiUrl = (path, workspaceOnly = false) => {
-  let url = config.services.monitorPlans.uri;
-
-  if (workspaceOnly === true || window.location.href.includes("/workspace")) {
-    url = `${url}/workspace`;
+export const getApiUrl = (path, context) => {
+  let url;
+  if (context === DatabaseContext.OFFICIAL) {
+    url = config.services.monitorPlans.uri;
+  } else if (context === DatabaseContext.WORKSPACE || window.location.href.includes("/workspace")) {
+    url = `${config.services.monitorPlans.uri}/workspace`;
   }
 
   return `${url}${path}`;
@@ -30,8 +32,7 @@ export const getMonitoringPlanById = async (id) => {
 export const getMonitoringPlans = async (
   orisCodes,
   monPlanIds = [],
-  forWorkspace = false,
-  submissionPeriods = [] //Added for polymorphism across data fetch calls
+  context = null,
 ) => {
   let queryString = "";
 
@@ -47,7 +48,7 @@ export const getMonitoringPlans = async (
     queryString = queryString + `&monPlanIds=${monPlanIds.join("|")}`;
   }
 
-  const url = getApiUrl(`/configurations?${queryString}`, forWorkspace);
+  const url = getApiUrl(`/configurations?${queryString}`, context);
   return secureAxios({
     method: "GET",
     url: url,
@@ -135,7 +136,7 @@ export const postCheckoutMonitoringPlanConfiguration = async (
   id,
   shouldHandleError = true
 ) => {
-  const url = getApiUrl(`/check-outs/plans/${id}`, true);
+  const url = getApiUrl(`/check-outs/plans/${id}`, DatabaseContext.WORKSPACE);
   try {
     return (
       await secureAxios({
@@ -150,7 +151,7 @@ export const postCheckoutMonitoringPlanConfiguration = async (
 };
 
 export const revertOfficialRecord = async (id) => {
-  const url = getApiUrl(`/plans/${id}/revert`, true);
+  const url = getApiUrl(`/plans/${id}/revert`, DatabaseContext.WORKSPACE);
   try {
     return (
       await secureAxios({
@@ -204,7 +205,7 @@ export const createMats = async (payload) => {
 };
 
 export const putLockTimerUpdateConfiguration = async (id) => {
-  const url = getApiUrl(`/check-outs/plans/${id}`, true);
+  const url = getApiUrl(`/check-outs/plans/${id}`, DatabaseContext.WORKSPACE);
   try {
     return handleResponse(
       await secureAxios({
@@ -262,7 +263,7 @@ export const saveMonitoringMats = async (payload) => {
 };
 
 export const deleteCheckInMonitoringPlanConfiguration = async (id) => {
-  const url = getApiUrl(`/check-outs/plans/${id}`, true);
+  const url = getApiUrl(`/check-outs/plans/${id}`, DatabaseContext.WORKSPACE);
   try {
     return (
       await secureAxios({
@@ -281,7 +282,7 @@ export const getCheckedOutLocations = async () => {
   if (!localStorage.getItem("ecmps_user")) {
     return { data: [] };
   }
-  const url = getApiUrl(`/check-outs/plans`, true);
+  const url = getApiUrl(`/check-outs/plans`, DatabaseContext.WORKSPACE);
 
   return secureAxios({
     method: "GET",
@@ -1237,7 +1238,7 @@ export const createSingleUnitMP = async (
 };
 
 export const importStackPipe = async (payload, draft) => {
-  let url = getApiUrl(`/stack-pipes/import`, true);
+  let url = getApiUrl(`/stack-pipes/import`, DatabaseContext.WORKSPACE);
   if (draft) {
     url = url + "?draft=true";
   }

--- a/src/utils/constants/databaseContext.js
+++ b/src/utils/constants/databaseContext.js
@@ -1,0 +1,4 @@
+export const DatabaseContext = {
+  OFFICIAL: "official",
+  WORKSPACE: "workspace",
+};


### PR DESCRIPTION
## Related Issues:

- [#5995](https://github.com/US-EPA-CAMD/easey-ui/issues/5995)

## Main Changes:

- Fixed several roles guard issues.
- Improved error handling in Configuration Manager.
- Added duplicate USC screen check in Configuration Manager.
- Fixed issue where recently inactivated Monitoring Plans were not showing on the Evaluation or Submission screens.
- Fixed a bug in the **`EvaluateRefresh`** component where an array was being improperly accessed as an `Object`.
- Added logic to check the `op_status_cd` of Units before allowing them to be associated with a monitor plan (if they haven't been associated with one before). This verifies they have the "OPR" or "FUT" code. Units with the code "CAN" are filtered from the displayed list entirely.
- Added ability to check out inactive plans so they can be reverted to official (it is not, however, possible to import data into an active plan).