### PR TITLE
Auth API changed to resolve JSON hijacking vulnerability by returning an object

### DIFF
--- a/src/components/SubmissionModal/SubmissionModal.js
+++ b/src/components/SubmissionModal/SubmissionModal.js
@@ -54,7 +54,7 @@ export const SubmissionModal = ({
       setLoading(true);  // Set loading to true before fetching data
       try {
         const result = await getCredentials(monitorPlanIds);
-        const list = result.data.data.map((el) => ({
+        const list = result.data.items.map((el) => ({
           title: "Certification Statement",
           content: el.statementText,
           expanded: false,

--- a/src/components/SubmissionModal/SubmissionModal.js
+++ b/src/components/SubmissionModal/SubmissionModal.js
@@ -54,7 +54,7 @@ export const SubmissionModal = ({
       setLoading(true);  // Set loading to true before fetching data
       try {
         const result = await getCredentials(monitorPlanIds);
-        const list = result.data.map((el) => ({
+        const list = result.data.data.map((el) => ({
           title: "Certification Statement",
           content: el.statementText,
           expanded: false,

--- a/src/utils/api/easeyAuthApi.test.js
+++ b/src/utils/api/easeyAuthApi.test.js
@@ -254,9 +254,9 @@ describe("Easey Auth API", () => {
         `${config.services.authApi.uri
         }/certifications/statements?monitorPlanIds=${monitorPlans.join("|")}`
       )
-      .reply(200, { data: {} });
+      .reply(200, { items: {} });
 
-    expect((await getCredentials(monitorPlans)).data).toEqual({ data: {} });
+    expect((await getCredentials(monitorPlans)).data).toEqual({ items: {} });
   });
 
   it("getPermissions", async () => {

--- a/src/utils/api/easeyAuthApi.test.js
+++ b/src/utils/api/easeyAuthApi.test.js
@@ -254,9 +254,9 @@ describe("Easey Auth API", () => {
         `${config.services.authApi.uri
         }/certifications/statements?monitorPlanIds=${monitorPlans.join("|")}`
       )
-      .reply(200, {});
+      .reply(200, { data: {} });
 
-    expect((await getCredentials(monitorPlans)).data).toEqual({});
+    expect((await getCredentials(monitorPlans)).data).toEqual({ data: {} });
   });
 
   it("getPermissions", async () => {


### PR DESCRIPTION
Auth API changed to resolve JSON hijacking vulnerability by returning an ArrayResponse object instead of returning an array directly from an API. ECMPS UI updated to handle that.