### PR TITLE
feature/#6074 Limit Display to the Most Recent Window in EM Submission Access

### DIFF
--- a/src/components/AdminMaintenance/EmSubmissionData/EmSubmissionData.js
+++ b/src/components/AdminMaintenance/EmSubmissionData/EmSubmissionData.js
@@ -233,7 +233,7 @@ export const EmSubmissionData = ({
 
 
   const openViewEditModalHandler = useCallback(
-    (row, isCreate = false) => {
+    (row, index, isCreate = false) => {
       const selectedData = row;
       const { facilityName, facilityId } = selectedData;
       selectedData.facilityNameAndId = `${facilityName} (${facilityId})`;
@@ -482,6 +482,7 @@ export const EmSubmissionData = ({
                     data.length === 0 
                     || selectedRows.length !== 1 //we can only submit the open request for one record at a time
                     || selectedRows.some(row => row.status !== 'CLOSED' && row.status !== 'NO WINDOW')
+                    || !selectedRows[0]?.isLatestRecord
                   } 
                 >
                   Open
@@ -499,6 +500,7 @@ export const EmSubmissionData = ({
                     || disableApproveBtn 
                     || selectedRows.length === 0 
                     || selectedRows.some(row => row.status !== 'OPEN')
+                    || selectedRows.some(row => row.isLatestRecord === false)
                   } 
                 >
                   Extend
@@ -515,6 +517,7 @@ export const EmSubmissionData = ({
                     data.length === 0 
                     || selectedRows.length === 0 
                     || selectedRows.some(row => row.status !== 'OPEN')
+                    || selectedRows.some(row => row.isLatestRecord === false)
                   }
                 >
                   Cancel
@@ -532,6 +535,7 @@ export const EmSubmissionData = ({
                     || disableApproveBtn 
                     || selectedRows.length === 0 
                     || selectedRows.some(row => row.status !== 'PENDING' && row.status !== 'CANCELLED')
+                    || selectedRows.some(row => row.isLatestRecord === false)
                   }
                 >
                   Approve

--- a/src/components/AdminMaintenance/FilterFormAdmin/FilterFormAdmin.js
+++ b/src/components/AdminMaintenance/FilterFormAdmin/FilterFormAdmin.js
@@ -8,6 +8,7 @@ import { DropdownSelection } from "../../DropdownSelection/DropdownSelection";
 import {
   Label,
   Button,
+  Checkbox
 } from "@trussworks/react-uswds";
 import { ComboBox } from "../../ComboBox/ComboBox";
 import {
@@ -68,6 +69,8 @@ const FilterFormAdmin = ({
     { code: testExtensionExemptionLabel, name: testExtensionExemptionLabel },
   ];
 
+  const [includeHistoricalWindows, setIncludeHistoricalWindows] = useState(false);
+
   addAriaLabelToDatatable();
 
   const processReportingPeriods = useCallback(async () => {
@@ -120,8 +123,26 @@ const FilterFormAdmin = ({
           quarter,
           status
         );
+        
         data.forEach((d) => (d.selected = false));
-        setTableData(data);
+
+        //preprocess data to get the latest record for each config
+        const latestOpenDateMap = new Map();
+        data.forEach(record => {
+            const location = record.locations;
+            const openDate = new Date(record.openDate);
+
+            if (!latestOpenDateMap.has(location) || openDate > latestOpenDateMap.get(location)) {
+                latestOpenDateMap.set(location, openDate);
+            }
+        });
+        data.forEach(record => {
+            record.isLatestRecord = new Date(record.openDate).getTime() === latestOpenDateMap.get(record.locations).getTime();
+        });
+
+        const filteredData = includeHistoricalWindows ? data : data.filter(record => record.isLatestRecord);
+
+        setTableData(filteredData);
       }
 
       if (section === QA_CERT_DATA_MAINTENANCE_STORE_NAME) {
@@ -180,7 +201,8 @@ const FilterFormAdmin = ({
     setSelectedRows,
     setTableData,
     typeSelection,
-    facilities
+    facilities,
+    includeHistoricalWindows
   ]);
 
   useEffect(() => {
@@ -351,6 +373,19 @@ const FilterFormAdmin = ({
               Apply Filter(s)
             </Button>
           </div>
+          {section === SUBMISSION_ACCESS_STORE_NAME ? (
+              <Checkbox
+                id="force-re-evaluation"
+                className="display-flex flex-row flex-justify-center"
+                name="include-historical-windows"
+                label="Include Historical Windows"
+                epa-testid={"include-historical-windows"}
+                data-testid={"include-historical-windows"}
+                checked={includeHistoricalWindows}
+                onChange={(e) => setIncludeHistoricalWindows(e.target.checked)}
+                disabled={false}
+              />
+            ) : ("")}
         </div>
 
     </div>

--- a/src/components/AdminMaintenance/QAMaintenance/QAMaintenanceData.js
+++ b/src/components/AdminMaintenance/QAMaintenance/QAMaintenanceData.js
@@ -127,8 +127,8 @@ const QAMaintenanceData = ({
   }); 
 
   const openViewModalHandler = useCallback(
-    async (row, isCreate = false) => {
-      const selectedData = row
+    async (row, index, isCreate = false) => {
+      const selectedData = row;
       const { systemIdentifier, componentIdentifier } = selectedData;
 
       selectedData.systemComponentID =


### PR DESCRIPTION
### **Related Ticket:**
- ticket [#6074](https://github.com/orgs/US-EPA-CAMD/projects/2/views/51?filterQuery=&sliceBy%5Bvalue%5D=EvanSun220&pane=issue&itemId=53268927&issue=US-EPA-CAMD%7Ceasey-ui%7C6074)
### **Updates:**
- Added checkbox "Include Historical Windows" on EM Submission Access to include/exclude historical windows.
- Updated logic related with enabling action buttons (i.e. Open/Extend/Cancel/Approve).
- Fixed the modal detail display issue on EM Submission and QA Maintenance page.

