### PR TITLE
facilities api response

### DIFF
--- a/src/components/HeaderInfo/HeaderInfo.js
+++ b/src/components/HeaderInfo/HeaderInfo.js
@@ -437,7 +437,7 @@ export const HeaderInfo = ({
         inWorkspace
       );
 
-      let { items: allViews } = await emApi.getViews().data;
+      let { items: allViews } = (await emApi.getViews()).data;
 
       let filteredViewData;
       if (inWorkspace)


### PR DESCRIPTION
The error indicates that the object returned from await emApi.getViews().data is undefined. This fix fixes this issue. 