### PR TITLE
Configuration Management: Evaluation & Submission Updates #6593

### DIFF
--- a/src/components/ConfigurationManagement/ConfigurationManagement.js
+++ b/src/components/ConfigurationManagement/ConfigurationManagement.js
@@ -886,6 +886,28 @@ export const ConfigurationManagement = ({
     });
   };
 
+  const filterFormState = () => {
+    const filteredStackPipes = formState.stackPipes.filter(
+      stackPipe => stackPipe?.retireDate !== stackPipe?.originalRecord?.retireDate
+      || stackPipe?.originalRecord == null
+    );
+    const filteredUnitStackConfigs = formState.unitStackConfigs.filter(
+      unitStackConfig => unitStackConfig?.endDate !== unitStackConfig?.originalRecord?.endDate
+      || unitStackConfig?.originalRecord == null
+    );
+    const filteredUnits = formState.units.filter(unit => 
+      unit.isToggled === true || 
+      filteredUnitStackConfigs.some(config => config.unitId === unit.unitId)
+    );
+    
+    return {
+      units: filteredUnits,
+      stackPipes: filteredStackPipes,
+      unitStackConfigs: filteredUnitStackConfigs
+    };
+  };
+  
+
   const initializeEditableFormState = (data, type) => {
     formDispatch({
       type,
@@ -898,18 +920,20 @@ export const ConfigurationManagement = ({
     });
   };
 
-  const mapFormStateToConfigurationsPayload = () => ({
+  const mapFormStateToConfigurationsPayload = () => {
+    const newFormState = filterFormState()
+    return {
     monitoringPlanCommentData: [],
     orisCode: userFacilities.find(
       (f) => f.facilityRecordId === selectedFacility
     ).facilityId,
-    unitStackConfigurationData: formState.unitStackConfigs.map((usc) => ({
+    unitStackConfigurationData: newFormState.unitStackConfigs.map((usc) => ({
       beginDate: usc.beginDate,
       endDate: usc.endDate,
       stackPipeId: usc.stackPipeId,
       unitId: usc.unitId,
     })),
-    monitoringLocationData: formState.stackPipes
+    monitoringLocationData: newFormState.stackPipes
       .map((sp) => ({
         unitId: null,
         stackPipeId: sp.stackPipeId,
@@ -919,7 +943,7 @@ export const ConfigurationManagement = ({
         ...unusedMonitoringLocationDataFields(),
       }))
       .concat(
-        formState.units.map((u) => ({
+        newFormState.units.map((u) => ({
           unitId: u.unitId,
           stackPipeId: null,
           activeDate: null,
@@ -929,7 +953,8 @@ export const ConfigurationManagement = ({
         }))
       ),
     version: MONITOR_PLAN_SCHEMA_VERSION,
-  });
+  };
+};
 
   const mapFormStateToSingleUnitPayload = (unit) => ({
     unitId: unit.unitId,

--- a/src/components/ConfigurationManagement/ConfigurationManagement.js
+++ b/src/components/ConfigurationManagement/ConfigurationManagement.js
@@ -887,16 +887,19 @@ export const ConfigurationManagement = ({
   };
 
   const filterFormState = () => {
-    const filteredStackPipes = formState.stackPipes.filter(
-      stackPipe => stackPipe?.retireDate !== stackPipe?.originalRecord?.retireDate
-      || stackPipe?.originalRecord == null
-    );
     const filteredUnitStackConfigs = formState.unitStackConfigs.filter(
       unitStackConfig => unitStackConfig?.endDate !== unitStackConfig?.originalRecord?.endDate
       || unitStackConfig?.originalRecord == null
     );
+    const filteredStackPipes = formState.stackPipes.filter(
+      (stackPipe) =>
+        filteredUnitStackConfigs.some(
+          (config) => config.stackPipeId === stackPipe.stackPipeId
+        ) ||
+        stackPipe?.retireDate !== stackPipe?.originalRecord?.retireDate ||
+        stackPipe?.originalRecord == null
+    );
     const filteredUnits = formState.units.filter(unit => 
-      unit.isToggled === true || 
       filteredUnitStackConfigs.some(config => config.unitId === unit.unitId)
     );
     


### PR DESCRIPTION
Ticket:
https://github.com/US-EPA-CAMD/easey-ui/issues/6593

Changes:
I added a comparison function where the stackPipe and unitStackConfigs are filtered using OriginalRecord. The units are filtered by using the isToggle value when set to true a new monitoring plan wants to be added, and also another filter we have to do is comparing filteredUnitStackConfigs with units because unitStacksConfigs were added to a new stack pipe.
Those monitoring plans, the single unit ones end and then were added to a new monitoring plan with the stack pipe.
