### PR TITLE
Fix where TEE data is not automatically selected when EM data is selected

### DIFF
--- a/src/components/EvaluateAndSubmit/EvaluateAndSubmit.js
+++ b/src/components/EvaluateAndSubmit/EvaluateAndSubmit.js
@@ -738,7 +738,7 @@ export const EvaluateAndSubmit = ({
         }
       }
 
-      const dataListLength = isForceReEvaluation ? dataList.length : 3;
+      const dataListLength = isForceReEvaluation ? dataList.length : 4;
 
       for (let i = 0; i < dataListLength; i++) {
         //Determine MP + QA Rerenders


### PR DESCRIPTION
Fixed a defect where, in the Submit screen, selecting EM data only will also automatically select any available MP, QAT, and QCE data. However, available TEE data is not automatically selected.
Updated the logic to also include TEE data for this scenario.