### PR TITLE
Updated to allow MP to begin dates up to 90 days in the future. (Ref: #6534)

### DIFF
--- a/src/components/ModalDetails/ModalDetails.js
+++ b/src/components/ModalDetails/ModalDetails.js
@@ -376,7 +376,16 @@ const ModalDetails = ({
             defaultValue={datePickerValue}
             disabled={isEditingDisabled}
             maxDate={
-              title !== "Protocol Gas"
+               // Allow future dates up to 90 days for specific components
+              ["Default", "Formula", "Load", "Location Attribute", "Method",
+                "Qualification", "Rectangular Duct WAF", "Span", "System",
+                "Unit Information", "Unit Fuel", "Unit Control", "Unit Capacity"].includes(title)
+                ? (() => {
+                    const futureDate = new Date(d.getTime() + (90 * 24 * 60 * 60 * 1000));
+                    return `${futureDate.getFullYear()}-${futureDate.getMonth() + 1}-${futureDate.getDate()}`;
+                  })()
+
+              : title !== "Protocol Gas"
                 ? `${d.getFullYear()}-${d.getMonth() + 1}-${d.getDate()}`
                 : null
             }


### PR DESCRIPTION
### Changes Made:
Updated backend MAXIMUM_FUTURE_DATE constant from 30 to 90 days
Modified frontend date picker to allow future date selection up to 90 days for:
Default
Formula
Load
Location Attribute
Method
Qualification
Rectangular Duct WAF
Span
System
Unit Fuel
Unit Control
Unit Capacity

### Testing:
Verified users can select and save begin dates up to 90 days in the future on all specified screens.

### Ref: 
PR: https://github.com/US-EPA-CAMD/easey-ecmps-ui/pull/1563
Issue: https://github.com/US-EPA-CAMD/easey-ui/issues/6534