### PR TITLE
update csp script-src  'unsafe-eval' and *.crazyegg.com and worker-sr…

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -41,7 +41,7 @@ http {
     add_header Strict-Transport-Security max-age=31536000;
 
     # CSP (Content-Security-Policy)
-    set $csp "default-src 'self' api.epa.gov; script-src 'self' 'nonce-$request_id' https://*.googletagmanager.com https://dap.digitalgov.gov https://script.crazyegg.com; style-src 'self' 'unsafe-inline' https:; img-src 'self' api.epa.gov data: www.googletagmanager.com https://*.google-analytics.com https://*.googletagmanager.com; font-src 'self' https:; connect-src 'self' api.epa.gov www.googletagmanager.com https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://script.crazyegg.com;";
+    set $csp "default-src 'self' api.epa.gov; script-src 'self' 'unsafe-eval' 'nonce-$request_id' https://*.googletagmanager.com https://dap.digitalgov.gov https://*.crazyegg.com; style-src 'self' 'unsafe-inline' https:; img-src 'self' api.epa.gov data: www.googletagmanager.com https://*.google-analytics.com https://*.googletagmanager.com; font-src 'self' https:; connect-src 'self' api.epa.gov www.googletagmanager.com https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.crazyegg.com; worker-src 'self' blob:";
     # Content-Security-Policy (for Chrome 25+, Firefox 23+, Safari 7+)
     add_header Content-Security-Policy $csp;
     # X-Content-Security-Policy (for Firefox 4.0+ and Internet Explorer 10+)


### PR DESCRIPTION
## Ticket
[ Content Security Policy (CSP) Header ](https://github.com/US-EPA-CAMD/easey-ui/issues/6551)

## Changes 

- Update CSP script-src  'unsafe-eval' , *.crazyegg.com and worker-src: blob: