### PR TITLE
QA tests no longer appearing in UI in the dev environmentTicket

### DIFF
--- a/src/components/QAImportHistoricalDataPreview/QAImportHistoricalDataPreview.js
+++ b/src/components/QAImportHistoricalDataPreview/QAImportHistoricalDataPreview.js
@@ -48,8 +48,11 @@ export const QAImportHistoricalDataPreview = ({
   const [tableData, setTableData] = useState(null);
   const [previewData, setPreviewData] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [dataTableId, setDataTableId] = useState('');
+  const [rowsAriaLabelData, setRowsAriaLabelData] = useState(null);
 
   const selectedRows = useRef();
+  const userClicked = useRef(false);
 
   const fetchDataPreviewRecords = async () => {
     if (reportingPeriodObj && !previewData) {
@@ -76,9 +79,11 @@ export const QAImportHistoricalDataPreview = ({
             ? [TEST_SUMMARY_KEY]
             : [CERT_EVENT_KEY, TEST_EXT_EXE_KEY];
           for (const dataKey of dataKeys) {
-            const rowsAriaLabelData = response.data[dataKey].map((e) => e.id);
+            const rowsAriaLabelData = response.data[dataKey].map((e) => e.unitId ?? e.id);
+            setRowsAriaLabelData(rowsAriaLabelData)
             const dataTableId = `#import-${dataKey}`;
-            assignAriaLabelsToDataTable(dataTableId, rowsAriaLabelData);
+            setDataTableId(dataTableId)
+            userClicked.current = true;
           }
         }
       } catch (err) {
@@ -86,6 +91,15 @@ export const QAImportHistoricalDataPreview = ({
       }
     }
   };
+
+  useEffect(() => {
+    //Runs only when button is clicked
+    if (userClicked.current) {
+      setTimeout(() => {
+          assignAriaLabelsToDataTable(dataTableId, rowsAriaLabelData);
+          userClicked.current = false;
+      }, 500); // ensure the DOM is fully updated
+  }}, [tableData, previewData]); // Runs when tableData or previewData changes
 
   useEffect(() => {
     setDisablePortBtn(true);

--- a/src/components/qaDatatablesContainer/QATestSummaryDataTable/QATestSummaryDataTable.js
+++ b/src/components/qaDatatablesContainer/QATestSummaryDataTable/QATestSummaryDataTable.js
@@ -149,13 +149,19 @@ const QATestSummaryDataTable = ({
         setLoading(true);
         getQATestSummary(locationSelectValue, testTypeCodes)
           .then((res) => {
-            if (res !== undefined && res.data.length > 0) {
-              finishedLoadingData(res.data);
-              setQATestSummary(res.data);
-              setShow(false);
-            } else {
-              finishedLoadingData([]);
-              setQATestSummary([]);
+            if(res !== undefined)
+            {
+              let items = res.data?.items;
+              if (items?.length > 0) {
+                finishedLoadingData(items);
+                setQATestSummary(items);
+                setShow(false);
+              }
+              else {
+
+                finishedLoadingData([]);
+                setQATestSummary([]);
+              }
             }
             setLoading(false);
           })


### PR DESCRIPTION
US-EPA-CAMD/easey-ui#6646

Changes
updated QATestSummaryDataTable with res.data?.items and updated QAImportHistoricalDataPreview with useEffect for when tableData and PreviewData changes the ariaLabels should updated as well.