### PR TITLE
Fix/6515 MATS submission screen

### DIFF
--- a/src/components/datatablesContainer/DataTableMatsSubmission/DataTableMatsSubmission.js
+++ b/src/components/datatablesContainer/DataTableMatsSubmission/DataTableMatsSubmission.js
@@ -103,7 +103,10 @@ const DataTableMatsSubmission = ({
       selector: (row) => row.testMethodCodes.join(", "),
     },
     { name: "Test Number", selector: (row) => row.testNumber },
-    { name: "Test Date", selector: (row) => formatDate(row.testDate) },
+    {
+      name: "Test Date",
+      selector: (row) => (row.testDate ? formatDate(row.testDate) : null),
+    },
     { name: "Test Comment", selector: (row) => row.testComment },
     {
       name: "Year / Quarter",


### PR DESCRIPTION
## Related Issues:

- https://github.com/US-EPA-CAMD/easey-ui/issues/6110
- https://github.com/US-EPA-CAMD/easey-ui/issues/6515

## Main Changes:

- In the table on the main MATS Data Submission screen, a new **`Date`** object is created from the `testDate` field, without checking if the value is empty (in which case it initializes to the epoch time, 1/1/1970). This adds a simple existence check to that column.