### PR TITLE
feat/#6656 Add A New importFromHistorical Endpoint on Emissions API

### DIFF
--- a/src/components/HeaderInfo/ImportHistoricalDataModal.js
+++ b/src/components/HeaderInfo/ImportHistoricalDataModal.js
@@ -2,8 +2,7 @@ import React, { useState } from "react";
 import UploadModal from "../UploadModal/UploadModal";
 import ReportingPeriodSelector from "../ReportingPeriodSelector/ReportingPeriodSelector";
 import {
-  exportEmissionsData,
-  importEmissionsData,
+  importFromHistorical,
 } from "../../utils/api/emissionsApi";
 import { useSelector } from "react-redux";
 import { successResponses } from "../../utils/api/apiUtils";
@@ -34,25 +33,11 @@ export const ImportHistoricalDataModal = ({
     setFinishedLoading(false);
 
     try {
-      const exportResp = await exportEmissionsData(selectedConfig.id, selectedYear, selectedQuarter, false)
-      if (!successResponses.includes(exportResp.status)) {
-        throw exportResp // go to catch block
-      }
-
-      // if exported data is empty
-      if( Object.keys(exportResp.data).length === 0 ){
-        throw {
-          data:{
-            message:["Import unsuccessful. There is no data for this reporting period"]
-          }
-        }
-      }
-        
-      const importResp = await importEmissionsData(exportResp.data);
+      const importResp = await importFromHistorical(selectedConfig.id, selectedYear, selectedQuarter);
       if (!successResponses.includes(importResp.status)) {
-        throw importResp // go to catch block
+        throw importResp
       }
-
+      
       setImportedFileErrorMsgs([]);
       portCallback(selectedYear, selectedQuarter)
     } catch (error) {

--- a/src/utils/api/emissionsApi.js
+++ b/src/utils/api/emissionsApi.js
@@ -33,6 +33,30 @@ export const getEmissionsReviewSubmit = async (
     .catch(handleError);
 };
 
+export const importFromHistorical = async (
+  monitorPlanId,
+  year,
+  quarter,
+) => {
+
+  const url = new URL(`${config.services.emissions.uri}/workspace/emissions/import-historical`);
+
+  const searchParams = new URLSearchParams({
+    monitorPlanId,
+    year,
+    quarter,
+    reportedValuesOnly: true,
+  });
+
+  const response = await secureAxios({
+    url: `${url.toString()}?${searchParams.toString()}`,
+    method: "POST", 
+   });
+
+  return handleResponse(response);
+
+}
+
 export const exportEmissionsData = async (
   monitorPlanId,
   year,

--- a/src/utils/api/emissionsApi.test.js
+++ b/src/utils/api/emissionsApi.test.js
@@ -37,6 +37,39 @@ describe("Emissions API", function () {
     });
   });
 
+  describe("importFromHistorical", () => {
+    it("should successfully call the historical import endpoint and return data", async () => {
+      const monitorPlanId = mockResponse.monitorPlanId;
+      const year = mockResponse.year.toString();
+      const quarter = mockResponse.quarter.toString();
+      const url = `${config.services.emissions.uri}/workspace/emissions/import-historical?monitorPlanId=${monitorPlanId}&year=${year}&quarter=${quarter}&reportedValuesOnly=true`;
+
+      mock.onPost(url).reply(201, mockResponse);
+
+      const resp = await emissionsApi.importFromHistorical(
+        monitorPlanId,
+        year,
+        quarter
+      );
+
+      expect(resp.data).toEqual(mockResponse);
+      expect(resp.status).toBe(201);
+    });
+
+    it("should throw an error when the import fails", async () => {
+      const monitorPlanId = mockResponse.monitorPlanId;
+      const year = mockResponse.year.toString();
+      const quarter = mockResponse.quarter.toString();
+      const url = `${config.services.emissions.uri}/workspace/emissions/import-historical?monitorPlanId=${monitorPlanId}&year=${year}&quarter=${quarter}&reportedValuesOnly=true`;
+
+      mock.onPost(url).reply(500);
+
+      await expect(
+        emissionsApi.importFromHistorical(monitorPlanId, year, quarter)
+      ).rejects.toThrow();
+    });
+  });
+
   describe("exportEmissionsData", function () {
     it("should get emissions data given year, quarter and monitoringPlanId", async function () {
       mock


### PR DESCRIPTION
### **Related Ticket:**

- ticket [#6656](https://github.com/US-EPA-CAMD/easey-ui/issues/6656)

### **Updates:**

- Updated the historicalImport function in ImportHistoricalDataModal to call the newly added endpoint.
- Added the wrapper function importFromHistorical in emissionsApi.
- Updated related tests.