### PR TITLE
fix/#6737 Open Records with Expired Close Date Should not be Submitted

### DIFF
--- a/src/components/EvaluateAndSubmit/utils/functions.js
+++ b/src/components/EvaluateAndSubmit/utils/functions.js
@@ -1,4 +1,5 @@
 import { getAllFacilities } from "../../../utils/api/facilityApi";
+import { currentDateTime } from "../../../utils/functions";
 
 export const getDropDownFacilities = async () => {
   const facilities = (await getAllFacilities()).data.items;
@@ -42,6 +43,16 @@ export const canSelectRow = (
     {
       if (!row.windowStatus) {
         return false;
+      }
+
+      if (row.windowExpiredDate) {
+        const expiredDate = new Date(row.windowExpiredDate);
+        const currentDate = currentDateTime();
+        expiredDate.setHours(0, 0, 0, 0);
+        currentDate.setHours(0, 0, 0, 0);
+        if (expiredDate < currentDate) {
+          row.isDisabled = true;
+        }
       }
     }
 


### PR DESCRIPTION
### **Related Ticket:**

- ticket [#6737](https://github.com/US-EPA-CAMD/easey-ui/issues/6737)

### **Updates:**

- Updated the canSelectRow in functions.js to disable checkbox of the EM record(s) if the access window is expired
