### PR TITLE
Feature/6852 single unit endpoint

### DIFF
--- a/src/utils/selectors/assert.js
+++ b/src/utils/selectors/assert.js
@@ -60,6 +60,8 @@ export const getDataTableApis = async (name, locationId, selectedLocation, planI
         .catch(error => log.log('getUnitCapacity failed', error));
     case unit:
       return mpApi.getMonitoringPlansUnit(selectedLocation)
+        // This endpoint returns a single unit object, so we need to format it to match the expected data structure
+        .then(res => ({ ...res, data: { items: res.data ? [res.data] : [] } }))
         .catch(error => log.log('getMonitoringPlansUnit failed', error));
     case unitProg:
       return mpApi.getUnitProgram(selectedLocation)


### PR DESCRIPTION
## Related Issues:

- https://github.com/US-EPA-CAMD/easey-ui/issues/6852

## Main changes:

- The `monitor-plan-mgmt/[workspace/]units/:id` endpoint was updated to return a single object representing a unit, rather than an object with an array of items, so the corresponding `mpApi.getMonitoringPlansUnit` call in the UI has been updated to handle the changed response.

## NOTE:

This branch was forked from [feature/6790-unnecessary_locid_parameter](https://github.com/US-EPA-CAMD/easey-ecmps-ui/pull/1616), so either this PR should be merged into that branch first, or this PR should be retargeted to `develop` and merged second.