### PR TITLE
Bug/Enhancement: deleted MP comments still visible

### DIFF
--- a/src/components/datatablesContainer/DataTableComments/DataTableComments.js
+++ b/src/components/datatablesContainer/DataTableComments/DataTableComments.js
@@ -27,6 +27,7 @@ import {
 } from "../../../additional-functions/prompt-to-save-unsaved-changes";
 import { ensure508 } from "../../../additional-functions/ensure-508";
 import { returnsFocusMpDatatableCreateBTN } from "../../../additional-functions/ensure-508";
+import PropTypes from 'prop-types';
 
 export const DataTableComments = ({
   locationSelectValue,
@@ -314,3 +315,7 @@ const mapStateToProps = (state) => {
 
 export default connect(mapStateToProps)(DataTableComments);
 export { mapStateToProps };
+
+DataTableComments.propTypes = {
+  setRevertedState: PropTypes.func.isRequired,
+};

--- a/src/components/datatablesContainer/DataTableComments/DataTableComments.js
+++ b/src/components/datatablesContainer/DataTableComments/DataTableComments.js
@@ -33,6 +33,7 @@ export const DataTableComments = ({
   user,
   checkout,
   revertedState,
+  setRevertedState,
   setUpdateRelatedTables,
   updateRelatedTables,
   currentTabIndex,
@@ -91,6 +92,7 @@ export const DataTableComments = ({
               setUpdateTable(false);
               setDataLoaded(true);
               setUpdateRelatedTables(false);
+              setRevertedState(false)
             })
             .catch((error) => {
             log.error("Error during getting comments", error);


### PR DESCRIPTION
ticket:
https://github.com/US-EPA-CAMD/easey-ui/issues/6791
changes:
Updated DataTableComments component. Reverted State was change to true and in comment component it needed to change as well to false in order for the API to trigger again.
