### PR TITLE
Feature/6863 export report multiple quarters

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,4 +1,5 @@
 import * as uswds from '@uswds/compile';
+import { series } from 'gulp';
 
 uswds.settings.version = 3;
 
@@ -9,8 +10,13 @@ uswds.paths.dist.js = './public/uswds/js';
 uswds.paths.dist.theme = './public/scss';
 
 export const init = async () => {
-  await uswds.copyAssets();
-  uswds.compile();
+  const task = series(
+    uswds.copyFonts,
+    uswds.copyImages,
+    uswds.copyJS,
+    uswds.compile,
+  );
+  await task();
 };
 
 export const compile = uswds.compile;

--- a/src/components/EvaluateAndSubmit/EvaluateAndSubmit.js
+++ b/src/components/EvaluateAndSubmit/EvaluateAndSubmit.js
@@ -580,28 +580,30 @@ export const EvaluateAndSubmit = ({
 
   const retrieveAndFormatData = async (dataListIndex, activeSet, submissionQueueOrderData) => {
 
+    const dataItem = dataList[dataListIndex];
     const resp = (
-      await dataList[dataListIndex].call(
+      await dataItem.call(
         storedFilters.current.orisCodes,
         storedFilters.current.monPlanIds,
-        storedFilters.current.submissionPeriods
+        storedFilters.current.submissionPeriods,
+        dataItem.type === "EM" ? true : undefined, // The EM call expects an `earliestOnly` parameter
       )
     );
 
     let data = resp.data?.items ?? resp.data;
 
     if (submissionQueueOrderData && submissionQueueOrderData.length) {
-      setDescription(data, submissionQueueOrderData, dataList[dataListIndex].name);
+      setDescription(data, submissionQueueOrderData, dataItem.name);
     }
 
     formatDataRows(
-      dataList[dataListIndex].ref,
+      dataItem.ref,
       data,
-      dataList[dataListIndex].type,
+      dataItem.type,
       activeSet
     );
 
-    dataList[dataListIndex].progressPending.current = false;
+    dataItem.progressPending.current = false;
     forceReloadTables();
   };
 

--- a/src/components/EvaluateAndSubmit/EvaluateAndSubmit.js
+++ b/src/components/EvaluateAndSubmit/EvaluateAndSubmit.js
@@ -161,7 +161,10 @@ export const EvaluateAndSubmit = ({
     {
       columns: emissionsColumns,
       ref: emissionsRef,
-      call: getEmissionsReviewSubmit,
+      call: (...args) => {
+        const emArgs = [...args, componentType === "Submission" ? "submit" : "evaluate"];
+        return getEmissionsReviewSubmit(...emArgs);
+      },
       rowId: "periodAbbreviation",
       name: "Emissions",
       type: "EM",
@@ -586,7 +589,6 @@ export const EvaluateAndSubmit = ({
         storedFilters.current.orisCodes,
         storedFilters.current.monPlanIds,
         storedFilters.current.submissionPeriods,
-        dataItem.type === "EM" ? true : undefined, // The EM call expects an `earliestOnly` parameter
       )
     );
 

--- a/src/components/export/ExportTab/ExportTab.js
+++ b/src/components/export/ExportTab/ExportTab.js
@@ -127,7 +127,12 @@ export const ExportTab = ({
   useEffect(() => { 
     const fetchTableData = async () => {
       const promises = dataTypes.current.map((dt) =>
-        dt.dataFetch([orisCode], [selectedConfigId], dt.reportCode === 'MPP' ? null : [reportingPeriod])
+        dt.dataFetch(
+          [orisCode],
+          [selectedConfigId],
+          dt.reportCode === 'MPP' ? null : [reportingPeriod],
+          dt.reportCode === 'EM' ? 'report' : null,
+        )
       );
       const responses = await Promise.all(promises);
 

--- a/src/utils/api/emissionsApi.js
+++ b/src/utils/api/emissionsApi.js
@@ -18,7 +18,7 @@ export const getEmissionsReviewSubmit = async (
   orisCodes,
   monPlanIds = [],
   quarters = [],
-  mode,
+  mode = 'report',
 ) => {
   let queryString = `orisCodes=${orisCodes.join("|")}&mode=${mode}`;
 

--- a/src/utils/api/emissionsApi.js
+++ b/src/utils/api/emissionsApi.js
@@ -17,7 +17,8 @@ const getApiUrl = (path = "") => {
 export const getEmissionsReviewSubmit = async (
   orisCodes,
   monPlanIds = [],
-  quarters = []
+  quarters = [],
+  earliestOnly = false,
 ) => {
   let queryString = `orisCodes=${orisCodes.join("|")}`;
 
@@ -27,6 +28,10 @@ export const getEmissionsReviewSubmit = async (
 
   if (quarters.length > 0) {
     queryString = queryString + `&quarters=${quarters.join("|")}`;
+  }
+
+  if (earliestOnly) {
+    queryString = queryString + `&earliest=true`;
   }
 
   let url = `${getApiUrl()}/emissions?${queryString}`;

--- a/src/utils/api/emissionsApi.js
+++ b/src/utils/api/emissionsApi.js
@@ -18,9 +18,9 @@ export const getEmissionsReviewSubmit = async (
   orisCodes,
   monPlanIds = [],
   quarters = [],
-  earliestOnly = false,
+  mode,
 ) => {
-  let queryString = `orisCodes=${orisCodes.join("|")}`;
+  let queryString = `orisCodes=${orisCodes.join("|")}&mode=${mode}`;
 
   if (monPlanIds.length > 0) {
     queryString = queryString + `&monPlanIds=${monPlanIds.join("|")}`;
@@ -28,10 +28,6 @@ export const getEmissionsReviewSubmit = async (
 
   if (quarters.length > 0) {
     queryString = queryString + `&quarters=${quarters.join("|")}`;
-  }
-
-  if (earliestOnly) {
-    queryString = queryString + `&earliest=true`;
   }
 
   let url = `${getApiUrl()}/emissions?${queryString}`;


### PR DESCRIPTION
## Related Issues:

- https://github.com/US-EPA-CAMD/easey-ui/issues/6863

## Main Changes:

- Updated the `getEmissionsReviewSubmit` function to include an optional `earliest` parameter. This parameter is currently used in the Evaluate & Submit module (to continue with the previous behavior), but is omitted in the Export & Report module (so that all emissions records are returned).