### PR TITLE
Feature/6864 evalute multiple quarters em

### DIFF
--- a/src/components/EvaluateAndSubmit/EvaluateAndSubmit.js
+++ b/src/components/EvaluateAndSubmit/EvaluateAndSubmit.js
@@ -586,7 +586,7 @@ export const EvaluateAndSubmit = ({
         storedFilters.current.orisCodes,
         storedFilters.current.monPlanIds,
         storedFilters.current.submissionPeriods,
-        dataItem.type === "EM" ? true : undefined, // The EM call expects an `earliestOnly` parameter
+        dataItem.type === "EM" && componentType === "Submission" ? true : undefined, // The EM call expects an `earliestOnly` parameter (default false)
       )
     );
 


### PR DESCRIPTION
## Related Issues:

- https://github.com/US-EPA-CAMD/easey-ui/issues/6864

## Main Changes:

- Retrieve all EM records for evaluations, rather than just the first.

## NOTE:

This branch was forked from `feature/6863-export_report_multiple_quarters_em`. If #1686 is merged first, this PR should be updated to target the `develop` branch.