### PR TITLE
Import file extension is case sensitive - easey-ecmps-ui

### DIFF
--- a/src/components/FileInput/FileInput.jsx
+++ b/src/components/FileInput/FileInput.jsx
@@ -109,7 +109,7 @@ export const FileInputForwardRef = (
           for (let j = 0; j < acceptedTypes.length; j += 1) {
             const fileType = acceptedTypes[parseInt(`${j}`)]
             allFilesAllowed =
-              file.name.indexOf(fileType) > 0 ||
+              (file.name.split('.').pop().toLowerCase() === (fileType.replace(".",""))) > 0 ||
               file.type.includes(fileType.replace(/\*/g, ''))
             if (allFilesAllowed) break
           }

--- a/src/components/ImportModal/ImportModal.js
+++ b/src/components/ImportModal/ImportModal.js
@@ -74,7 +74,7 @@ const ImportModal = ({
 
   const validateJSON = (name, type, event) => {
     const fileTypeManual = name.split(".");
-    if (fileTypeManual[fileTypeManual.length - 1] !== "json") {
+    if (fileTypeManual[fileTypeManual.length - 1].toLowerCase() !== "json") {
       setHasFormatError(true);
       setDisablePortBtn(true);
     } else {


### PR DESCRIPTION
ticket: 
https://github.com/US-EPA-CAMD/easey-ui/issues/6267
changes:
Updated preventInvalidFiles with logic for all combinations of upper and lower case of type files. For all Mats import FileInput.preventInvalidFiles is use and for Monitoring plan ImportModal.validateJSON is use. 