### PR TITLE
508: Failed login message box

### DIFF
--- a/src/additional-functions/app-error.js
+++ b/src/additional-functions/app-error.js
@@ -21,7 +21,6 @@ const displayAppMessage = (messages, type, hideFunc) => {
       .querySelectorAll("svg path")
       .forEach((element) => (element.tabIndex = -1));
 
-    errorMsg.addEventListener("click", hideFunc);
 
     const svgElements = document.querySelectorAll(`${containerId} .MuiSvgIcon-root`);
     const xButtonSvg = svgElements[1];

--- a/src/additional-functions/app-error.js
+++ b/src/additional-functions/app-error.js
@@ -20,7 +20,7 @@ const displayAppMessage = (messages, type, hideFunc) => {
     document
       .querySelectorAll("svg path")
       .forEach((element) => (element.tabIndex = -1));
-
+    errorMsg.focus();
 
     const svgElements = document.querySelectorAll(`${containerId} .MuiSvgIcon-root`);
     const xButtonSvg = svgElements[1];

--- a/src/additional-functions/app-error.test.js
+++ b/src/additional-functions/app-error.test.js
@@ -32,13 +32,6 @@ describe("Test displayAppError", () => {
 
     expect(appErrorMessage.classList).not.toContain('display-none');
     expect(appErrorMessageText.innerHTML).toBe("Some Error");
-
-    // Clicking on the appErrorMessage container should fire hideAppError
-    // and close it (display: none, empty error text)
-    fireEvent.click(appErrorMessage);
-
-    expect(appErrorMessage.classList).toContain('display-none');
-    expect(appErrorMessageText.innerHTML).toBe("");
   });
 
   it("Should not error if called when there is no appErrorMessage container",

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -90,7 +90,7 @@ const Layout = (props) => {
             ) : null}
             <div
               id="appErrorMessage"
-              tabIndex="-1"
+              tabIndex="0"
               aria-live="polite"
               className="border-1px margin-y-2 padding-2 bg-secondary-lighter
                          text-bold text-secondary-vivid react-transition display-none"

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -90,8 +90,9 @@ const Layout = (props) => {
             ) : null}
             <div
               id="appErrorMessage"
-              tabIndex="0"
-              aria-live="polite"
+              tabIndex="-1"
+              aria-live="assertive"
+              aria-atomic="true"
               className="border-1px margin-y-2 padding-2 bg-secondary-lighter
                          text-bold text-secondary-vivid react-transition display-none"
             >


### PR DESCRIPTION
Ticket:
https://github.com/US-EPA-CAMD/easey-ui/issues/6832

Changes:
Replace tabindex to 0. Text is accessible to screen readers.  Remove addEventListener.click created by displayAppMessage. We always want to click on the X button to exit message. 