### PR TITLE
Fix/6899 configuration management forbidden resource

### DIFF
--- a/src/components/ConfigurationManagement/ConfigurationManagement.js
+++ b/src/components/ConfigurationManagement/ConfigurationManagement.js
@@ -974,7 +974,18 @@ export const ConfigurationManagement = ({
   };
 
   const sendConfigurationsPayload = (draft) => {
-    return importMP(mapFormStateToConfigurationsPayload(), {
+    const payload = mapFormStateToConfigurationsPayload();
+    // If there are no changes to send, return a resolved promise with empty results.
+    if (
+      payload.monitoringLocationData.length === 0 &&
+      payload.unitStackConfigurationData.length === 0
+    ) {
+      return Promise.resolve({
+        data: { newPlans: [], endedPlans: [] },
+      });
+    }
+
+    return importMP(payload, {
       draft,
       shouldHandleError: false,
     });


### PR DESCRIPTION
## Related Issues:

- https://github.com/US-EPA-CAMD/easey-ui/issues/6899

## Main Changes:

- If there are no changes made to an existing MP on the Configuration Management screen, don't call the `/monitor-plan-mgmt/plans/import` endpoint.