### PR TITLE
Linearity button tagging

### DIFF
--- a/src/components/ConfirmActionModal/ConfirmActionModal.js
+++ b/src/components/ConfirmActionModal/ConfirmActionModal.js
@@ -1,6 +1,7 @@
 import React, { useRef } from "react";
 import { getTableRowActionAriaLabel } from "../../utils/selectors/QACert/TestSummary";
 import { ButtonGroup, Modal, ModalFooter, ModalHeading, ModalToggleButton } from "@trussworks/react-uswds";
+import PropTypes from 'prop-types';
 
 const defaultHeading = 'Confirmation'
 const defaultDescription = 'Please confirm your action'
@@ -65,5 +66,9 @@ const ConfirmActionModal = ({
     </>
   )
 }
+
+ConfirmActionModal.propTypes = {
+  rowNumber: PropTypes.number.isRequired,
+};
 
 export default ConfirmActionModal

--- a/src/components/ConfirmActionModal/ConfirmActionModal.js
+++ b/src/components/ConfirmActionModal/ConfirmActionModal.js
@@ -17,6 +17,7 @@ const ConfirmActionModal = ({
   onConfirm,
   onCancel,
   row,
+  rowNumber,
   dataTableName
 }) => {
   const modalRef = useRef()
@@ -25,7 +26,7 @@ const ConfirmActionModal = ({
       <ModalToggleButton 
         modalRef={modalRef} 
         opener outline={true} 
-        aria-label={getTableRowActionAriaLabel(dataTableName, row, 'Remove')}
+        aria-label={getTableRowActionAriaLabel(dataTableName, row, 'Remove', rowNumber)}
         data-testid="Remove"
       >
         {buttonText}

--- a/src/components/ConfirmActionModal/ConfirmActionModal.js
+++ b/src/components/ConfirmActionModal/ConfirmActionModal.js
@@ -68,10 +68,10 @@ const ConfirmActionModal = ({
 }
 
 ConfirmActionModal.propTypes = {
-  row: PropTypes.object,
-  rowNumber: PropTypes.number,
-  dataTableName:PropTypes.string,
-  onConfirm: PropTypes.func
+  row: PropTypes.object.isRequired,
+  rowNumber: PropTypes.number.isRequired,
+  dataTableName:PropTypes.string.isRequired,
+  onConfirm: PropTypes.func.isRequired
 };
 
 export default ConfirmActionModal

--- a/src/components/ConfirmActionModal/ConfirmActionModal.js
+++ b/src/components/ConfirmActionModal/ConfirmActionModal.js
@@ -1,7 +1,6 @@
 import React, { useRef } from "react";
 import { getTableRowActionAriaLabel } from "../../utils/selectors/QACert/TestSummary";
 import { ButtonGroup, Modal, ModalFooter, ModalHeading, ModalToggleButton } from "@trussworks/react-uswds";
-import PropTypes from 'prop-types';
 
 const defaultHeading = 'Confirmation'
 const defaultDescription = 'Please confirm your action'
@@ -66,12 +65,5 @@ const ConfirmActionModal = ({
     </>
   )
 }
-
-ConfirmActionModal.propTypes = {
-  row: PropTypes.object.isRequired,
-  rowNumber: PropTypes.number.isRequired,
-  dataTableName:PropTypes.string.isRequired,
-  onConfirm: PropTypes.func.isRequired
-};
 
 export default ConfirmActionModal

--- a/src/components/ConfirmActionModal/ConfirmActionModal.js
+++ b/src/components/ConfirmActionModal/ConfirmActionModal.js
@@ -1,7 +1,7 @@
 import React, { useRef } from "react";
 import { getTableRowActionAriaLabel } from "../../utils/selectors/QACert/TestSummary";
 import { ButtonGroup, Modal, ModalFooter, ModalHeading, ModalToggleButton } from "@trussworks/react-uswds";
-
+import PropTypes from 'prop-types';
 
 const defaultHeading = 'Confirmation'
 const defaultDescription = 'Please confirm your action'
@@ -66,5 +66,12 @@ const ConfirmActionModal = ({
     </>
   )
 }
+
+ConfirmActionModal.propTypes = {
+  row: PropTypes.object,
+  rowNumber: PropTypes.number,
+  dataTableName:PropTypes.string,
+  onConfirm: PropTypes.func
+};
 
 export default ConfirmActionModal

--- a/src/components/QADataTableRender/QADataTableRender.js
+++ b/src/components/QADataTableRender/QADataTableRender.js
@@ -129,11 +129,6 @@ const QADataTableRender = ({
           }`}
         aria-expanded={false}
         role="button"
-        aria-label={getTableRowActionAriaLabel(
-            dataTableName,
-            row,
-            "Edit"
-        )}
         tabIndex="0"
         aria-hidden="false"
       />
@@ -167,11 +162,6 @@ const QADataTableRender = ({
         id={`collapseRow${dataTableName.replaceAll(" ", "-")}${row.col1}${index + 1
           }`}
         role="button"
-        aria-label={getTableRowActionAriaLabel(
-          dataTableName,
-          row,
-          "Remove"
-        )}
         tabIndex="0"
         aria-expanded={true}
         aria-hidden="false"
@@ -193,6 +183,7 @@ const QADataTableRender = ({
         cell: (row, index) => {
           // *** normalize the row object to be in the format expected by DynamicTabs
           const normalizedRow = normalizeRowObjectFormat(row, columnNames);
+          const rowNumber = index + 1;
           return (
             <div>
               {/* user is logged in and config is checked out */}
@@ -213,7 +204,8 @@ const QADataTableRender = ({
                         aria-label={getTableRowActionAriaLabel(
                           dataTableName,
                           row,
-                          "Edit"
+                          "Edit",
+                          rowNumber
                         )}
                         data-testid="Edit"
                       >
@@ -222,6 +214,7 @@ const QADataTableRender = ({
 
                       {!row?.isSubmitted && (
                         <RemoveButton
+                          rowNumber={rowNumber}
                           row={row}
                           dataTableName={dataTableName}
                           onConfirm={() => onRemoveHandler(normalizedRow)}
@@ -242,7 +235,8 @@ const QADataTableRender = ({
                     aria-label={getTableRowActionAriaLabel(
                       dataTableName,
                       row,
-                      "View"
+                      "View",
+                      rowNumber
                     )}
                     outline={true}
                     id={`btnEditView${dataTableName.replaceAll(" ", "-")}${index + 1
@@ -294,12 +288,13 @@ const QADataTableRender = ({
 
 export default QADataTableRender;
 
-const RemoveButton = ({ onConfirm, row, dataTableName }) => {
+const RemoveButton = ({ onConfirm, row, dataTableName, rowNumber }) => {
   return (
     <ConfirmActionModal
       buttonText="Remove"
       description="Are you sure you want to remove the selected data?"
       onConfirm={onConfirm}
+      rowNumber={rowNumber}
       row={row}
       dataTableName={dataTableName}
     />

--- a/src/components/QADataTableRender/QADataTableRender.js
+++ b/src/components/QADataTableRender/QADataTableRender.js
@@ -21,6 +21,7 @@ import {
 
 import { cleanUp508, ensure508 } from "../../additional-functions/ensure-508";
 import ConfirmActionModal from "../ConfirmActionModal/ConfirmActionModal";
+import PropTypes from 'prop-types';
 
 const QADataTableRender = ({
   columnNames,
@@ -299,4 +300,11 @@ const RemoveButton = ({ onConfirm, row, dataTableName, rowNumber }) => {
       dataTableName={dataTableName}
     />
   );
+};
+
+RemoveButton.propTypes = {
+  row: PropTypes.object.isRequired,
+  rowNumber: PropTypes.number.isRequired,
+  dataTableName:PropTypes.string.isRequired,
+  onConfirm: PropTypes.func.isRequired
 };

--- a/src/components/QADataTableRender/QADataTableRender.js
+++ b/src/components/QADataTableRender/QADataTableRender.js
@@ -129,6 +129,11 @@ const QADataTableRender = ({
           }`}
         aria-expanded={false}
         role="button"
+        aria-label={getTableRowActionAriaLabel(
+            dataTableName,
+            row,
+            "Edit"
+        )}
         tabIndex="0"
         aria-hidden="false"
       />
@@ -162,6 +167,11 @@ const QADataTableRender = ({
         id={`collapseRow${dataTableName.replaceAll(" ", "-")}${row.col1}${index + 1
           }`}
         role="button"
+        aria-label={getTableRowActionAriaLabel(
+          dataTableName,
+          row,
+          "Remove"
+        )}
         tabIndex="0"
         aria-expanded={true}
         aria-hidden="false"

--- a/src/utils/selectors/QACert/TestSummary.js
+++ b/src/utils/selectors/QACert/TestSummary.js
@@ -698,7 +698,7 @@ export const getListOfRadioControls = (controlInputs) => {
 };
 
 // Show aria-label for any action (View, Edit, Remove) in any table provided a unique Id based on table type
-export const getTableRowActionAriaLabel = (dataTableName, row, action) => {
+export const getTableRowActionAriaLabel = (dataTableName, row, action, rowNumber) => {
   let result;
   switch (dataTableName) {
     case "Test Summary Data": //unique ID is test number, i.e. col4
@@ -711,7 +711,7 @@ export const getTableRowActionAriaLabel = (dataTableName, row, action) => {
     case "Linearity Test": 
     case "Protocol Gas":
     case "Linearity Injection":
-      result = `${action} for ${row.col1} ${dataTableName}`;
+      result = `${action} for ${rowNumber} ${dataTableName}`;
       break;
     default:
       result = `not implemented yet`;

--- a/src/utils/selectors/QACert/TestSummary.js
+++ b/src/utils/selectors/QACert/TestSummary.js
@@ -711,7 +711,7 @@ export const getTableRowActionAriaLabel = (dataTableName, row, action, rowNumber
     case "Linearity Test": 
     case "Protocol Gas":
     case "Linearity Injection":
-      result = `${action} for ${rowNumber} ${dataTableName}`;
+      result = `${action} for row ${rowNumber} in ${dataTableName}`;
       break;
     default:
       result = `not implemented yet`;

--- a/src/utils/selectors/QACert/TestSummary.js
+++ b/src/utils/selectors/QACert/TestSummary.js
@@ -708,6 +708,11 @@ export const getTableRowActionAriaLabel = (dataTableName, row, action) => {
     case "Test Extension Exemption": //unique ID is Extension or Exemption Code, i.e. col9
       result = `${action} for ${row.col9}`;
       break;
+    case "Linearity Test": 
+    case "Protocol Gas":
+    case "Linearity Injection":
+      result = `${action} for ${row.col1} ${dataTableName}`;
+      break;
     default:
       result = `not implemented yet`;
       break;


### PR DESCRIPTION
ticket:
https://github.com/US-EPA-CAMD/easey-ui/issues/6845
changes:
Updated edit and remove tags with aria-label according to their dataTableNames. 
Updated aria-label with ${action} for row ${rowNumber} in ${dataTableName}