### PR TITLE
feature/#6839 508 MP New Browser Tab Evaluation

### DIFF
--- a/src/additional-functions/evaluate-configs.js
+++ b/src/additional-functions/evaluate-configs.js
@@ -49,6 +49,7 @@ const evalStatusStyle = (status) => {
       <div className={alertStyle}>
         <button
           className={"hyperlink-btn cursor-pointer"}
+          aria-label="open evaluation report in a new tab"
           onClick={() => displayReport(params)}
         >
           {evalStatusText(status)}

--- a/src/components/EmissionsViewTable/EmissionsViewTable.js
+++ b/src/components/EmissionsViewTable/EmissionsViewTable.js
@@ -73,6 +73,7 @@ export const EmissionsViewTable = ({ monitorPlanId, filterApply, setFilterApply,
                 <div>
                     <button
                         className={"hyperlink-btn cursor-pointer"}
+                        aria-label="open emissions report in a new tab"
                         onClick={() => displayEmissionsReport(reduxCurrentTab.orisCode, monitorPlanId, row.rptyear, row.rptquarter, row.dateHour)}
                     >
                         View Error

--- a/src/components/HeaderInfo/HeaderInfo.js
+++ b/src/components/HeaderInfo/HeaderInfo.js
@@ -746,6 +746,7 @@ export const HeaderInfo = ({
       <div className={alertStyle}>
         <button
           className={"hyperlink-btn cursor-pointer"}
+          aria-label="open evaluation report in a new tab"
           onClick={() => displayReport(params)}
         >
           {

--- a/src/utils/functions.js
+++ b/src/utils/functions.js
@@ -219,6 +219,7 @@ export const addEvalStatusCell = (columns, callback) =>
           {evalStatusesWithLinks.has(row.evalStatusCode) ? (
             <button
               className={"hyperlink-btn cursor-pointer"}
+              aria-label="open evaluation report in a new tab"
               onClick={() => {
                 callback(row, false);
               }}
@@ -228,6 +229,7 @@ export const addEvalStatusCell = (columns, callback) =>
           ) : otherStatusesWithLinks.has(row.evalStatusCode) && row?.severityDescription  ? (
             <button
               className={"hyperlink-btn cursor-pointer"}
+              aria-label="open evaluation report in a new tab"
               onClick={() => {
                 callback(row, false);
               }}
@@ -237,6 +239,7 @@ export const addEvalStatusCell = (columns, callback) =>
           ) : otherStatusesWithLinks.has(row.evalStatusCode) ? ( // if no chk session is present
             <button
               className={"hyperlink-btn cursor-pointer"}
+              aria-label="open evaluation report in a new tab"
               onClick={() => {
                 callback(row, false);
               }}


### PR DESCRIPTION
## Related Ticket:

- ticket [#6839](https://github.com/US-EPA-CAMD/easey-ui/issues/6839)

## Updates:

- Updated the aria-label for the eval status link to indicate that a new tab will be opened to display the content
