### PR TITLE
QA Cert Preview focus

### DIFF
--- a/src/additional-functions/focus-trap.js
+++ b/src/additional-functions/focus-trap.js
@@ -4,9 +4,10 @@
  *    Params:
  *      selector - css selector for component displayed on top
  *      callback - (optional), potential extra functions to call
+ *      firstFocusElementById - Id of element to focus
  *                             [only one implemented so far is 'Escape' press for modal]
  *****/
-export const focusTrap = (selector, callback = () => {}) => {
+export const focusTrap = (selector, callback = () => {}, focustElementById) => {
   // *** identify focusable component elements
   const componentFocusableElements =
     'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
@@ -16,6 +17,13 @@ export const focusTrap = (selector, callback = () => {}) => {
   const focusableComponentContent = component.querySelectorAll(
     componentFocusableElements
   );
+  let elementWithId
+  if(focustElementById)
+  {
+     elementWithId = Array.from(focusableComponentContent).find(
+      el => el.id == focustElementById
+    );
+  }
 
   // *** isolate first element to be focused inside component
   const firstComponentFocusableElement = component.querySelectorAll(
@@ -56,7 +64,10 @@ export const focusTrap = (selector, callback = () => {}) => {
   // *** focus on the first element as soon as modal pops open and the first focusable
   // *** element is in scope
   setTimeout(() => {
-    firstComponentFocusableElement.focus();
+    if(focustElementById)
+        elementWithId.focus();
+    else
+        firstComponentFocusableElement.focus();
   });
   return {
     component,

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -107,7 +107,8 @@ export const Modal = ({
   const modalClassName = "modal-wrapper radius-md";
 
   return ReactDom.createPortal(
-    <div role="dialog" aria-modal="true">
+    <div role="dialog" aria-modal="true" aria-labelledby="">
+    <h2 id="modal-title">Preview Your Data</h2>
       {showDarkBg ? <div className="usa-overlay is-visible"></div> : null}
       <div ref={modalRef}>
         <modalContext.Provider value={{ close }}>

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -23,6 +23,7 @@ export const Modal = ({
   left = "25%",
   returnFocus,
   save,
+  firstFocusElementById,
   saveStatus = DataStatus.IDLE,
   show,
   showCancel,
@@ -62,7 +63,7 @@ export const Modal = ({
   }, []);
 
   useEffect(() => {
-    const { handleKeyPress } = focusTrap(".modal-content", close);
+    const { handleKeyPress } = focusTrap(".modal-content", close, firstFocusElementById);
 
     // *** FOCUS TRAP
     document.addEventListener("keydown", handleKeyPress);
@@ -73,8 +74,13 @@ export const Modal = ({
     });
 
     setTimeout(() => {
-      if (document.querySelector("#closeModalBtn")) {
-        document.querySelector("#closeModalBtn").focus();
+      if(firstFocusElementById)
+        document.getElementById(firstFocusElementById).focus();
+      else
+      {
+        if (document.querySelector("#closeModalBtn")) {
+          document.querySelector("#closeModalBtn").focus();
+        }
       }
     });
 
@@ -107,7 +113,7 @@ export const Modal = ({
   const modalClassName = "modal-wrapper radius-md";
 
   return ReactDom.createPortal(
-    <div role="dialog" aria-modal="true" aria-labelledby="">
+    <div role="dialog" aria-modal="true" aria-labelledby="modal-title">
     <h2 id="modal-title">Preview Your Data</h2>
       {showDarkBg ? <div className="usa-overlay is-visible"></div> : null}
       <div ref={modalRef}>

--- a/src/components/QACertEventHeaderInfo/QACertEventHeaderInfo.js
+++ b/src/components/QACertEventHeaderInfo/QACertEventHeaderInfo.js
@@ -387,6 +387,7 @@ export const QACertEventHeaderInfo = ({
           title="Import Historical QA Cert Event, Extension & Exemption Data"
           disableExitBtn={disablePortBtn}
           save={() => importHistoricalData()}
+          firstFocusElementById={"preview-button"}
         >
           <QAImportHistoricalDataPreview
             locations={locations}

--- a/src/components/QACertTestSummaryHeaderInfo/QACertTestSummaryHeaderInfo.js
+++ b/src/components/QACertTestSummaryHeaderInfo/QACertTestSummaryHeaderInfo.js
@@ -435,6 +435,7 @@ export const QACertTestSummaryHeaderInfo = ({
           save={() => {
             importHistoricalData();
           }}
+          firstFocusElementById={"preview-button"}
           children={
             <QAImportHistoricalDataPreview
               locations={locations}

--- a/src/components/QAImportHistoricalDataPreview/QAImportHistoricalDataPreview.js
+++ b/src/components/QAImportHistoricalDataPreview/QAImportHistoricalDataPreview.js
@@ -54,14 +54,6 @@ export const QAImportHistoricalDataPreview = ({
   const selectedRows = useRef();
   const userClicked = useRef(false);
 
-    useEffect(() => {
-      requestAnimationFrame(() => {
-     const wrapper = document.getElementById("preview-button");
-      if (wrapper) {
-        const realButton = wrapper.querySelector("button");
-        realButton?.focus();
-      }})
-    }, []);
 
   const fetchDataPreviewRecords = async () => {
     if (reportingPeriodObj && !previewData) {
@@ -170,15 +162,14 @@ export const QAImportHistoricalDataPreview = ({
           />
         </div>
         <div className="grid-col-fill padding-x-9 padding-top-3">
-          <div id="preview-button">
           <Button
             tabIndex={0}
             className="width-card"
             onClick={() => fetchDataPreviewRecords()}
+            id="preview-button"
           >
             Preview
           </Button>
-          </div>
         </div>
       </div>
       {loading ? (

--- a/src/components/QAImportHistoricalDataPreview/QAImportHistoricalDataPreview.js
+++ b/src/components/QAImportHistoricalDataPreview/QAImportHistoricalDataPreview.js
@@ -54,6 +54,15 @@ export const QAImportHistoricalDataPreview = ({
   const selectedRows = useRef();
   const userClicked = useRef(false);
 
+    useEffect(() => {
+      requestAnimationFrame(() => {
+     const wrapper = document.getElementById("preview-button");
+      if (wrapper) {
+        const realButton = wrapper.querySelector("button");
+        realButton?.focus();
+      }})
+    }, []);
+
   const fetchDataPreviewRecords = async () => {
     if (reportingPeriodObj && !previewData) {
       setLoading(true);
@@ -161,12 +170,15 @@ export const QAImportHistoricalDataPreview = ({
           />
         </div>
         <div className="grid-col-fill padding-x-9 padding-top-3">
+          <div id="preview-button">
           <Button
+            tabIndex={0}
             className="width-card"
             onClick={() => fetchDataPreviewRecords()}
           >
             Preview
           </Button>
+          </div>
         </div>
       </div>
       {loading ? (


### PR DESCRIPTION
ticket:
https://github.com/US-EPA-CAMD/easey-ui/issues/6842

chages:
Added modal-title to make let screen readers know they are in  a modal. Focus <Button> from "@trussworks/react-uswds" right when the modal opens. 
Updated focus-trap.js logic with the desired element that we want by passing elementId to the Modal Component. Otherwise, always focus the first element. 