### PR TITLE
 Resolve ANDI accessibility issue in MATS HTML reports - Part of Create a human readable version of metadata.xml in MATS submission [#6819]

### DIFF
--- a/src/utils/matsHtmlReportGenerator.js
+++ b/src/utils/matsHtmlReportGenerator.js
@@ -311,7 +311,7 @@ const generateCodeMappingsSection = (data) => {
   if (data.pollutantDescriptions && data.pollutantDescriptions.length > 0) {
     pollutantsHtml = `
       <h3>Pollutants</h3>
-      <table role="table" aria-label="Pollutant codes and descriptions">
+      <table aria-label="Pollutant codes and descriptions">
         <thead>
           <tr>
             <th scope="col">Code</th>
@@ -333,7 +333,7 @@ const generateCodeMappingsSection = (data) => {
   if (data.testMethodDescriptions && data.testMethodDescriptions.length > 0) {
     testMethodsHtml = `
       <h3>Test Methods</h3>
-      <table role="table" aria-label="Test method codes and descriptions">
+      <table aria-label="Test method codes and descriptions">
         <thead>
           <tr>
             <th scope="col">Code</th>


### PR DESCRIPTION
 **Issue:** 
ANDI accessibility testing flagged redundant role="table"
  attributes on semantic HTML `<table> `elements in the MATS metadata HTML reports.

  **Solution:** 
Remove explicit role="table" attributes since semantic `<table>` elements already have implicit table roles.

  **Changes:**
  -  Remove role="table" attributes from <table> elements

 
