### PR TITLE
fix:remove frontend validation

### DIFF
--- a/src/components/ConfigurationManagement/ConfigurationManagement.js
+++ b/src/components/ConfigurationManagement/ConfigurationManagement.js
@@ -844,13 +844,6 @@ export const ConfigurationManagement = ({
       newErrorMsgs.push(errorMessages.NOT_CHECKED_OUT);
     }
 
-    if (checkForDuplicateStackPipeIds()) {
-      newErrorMsgs.push(errorMessages.DUPLICATE_STACKPIPE_IDS);
-    }
-
-    if (checkForDuplicateUnitStackConfigs()) {
-      newErrorMsgs.push(errorMessages.DUPLICATE_UNIT_STACK_CONFIGS);
-    }
 
     setErrorMsgs(newErrorMsgs);
     if (newErrorMsgs.length) return;

--- a/src/components/ConfigurationManagement/ConfigurationManagement.js
+++ b/src/components/ConfigurationManagement/ConfigurationManagement.js
@@ -62,9 +62,6 @@ import "./ConfigurationManagement.scss";
 
 const DEFAULT_DROPDOWN_TEXT = "-- Select a value --";
 const errorMessages = {
-  DUPLICATE_STACKPIPE_IDS: "Stack/Pipe IDs must be unique.",
-  DUPLICATE_UNIT_STACK_CONFIGS:
-    "Unit/Stack Configurations with the same Unit and Stack/Pipe cannot have the same begin date.",
   EDITS_PENDING: "Please complete any pending edits before continuing.",
   NOT_CHECKED_OUT: "You must check out the facility before saving.",
 };
@@ -675,22 +672,6 @@ export const ConfigurationManagement = ({
 
   /* HANDLERS */
 
-  const checkForDuplicateStackPipeIds = () => {
-    const stackPipeIds = formState.stackPipes.map((sp) => sp.stackPipeId);
-    if (new Set(stackPipeIds).size !== stackPipeIds.length) {
-      return true;
-    }
-  };
-
-  const checkForDuplicateUnitStackConfigs = () => {
-    const unitStackConfigs = formState.unitStackConfigs
-      .map((usc) => [usc.unitId, usc.stackPipeId, usc.beginDate])
-      .map(JSON.stringify);
-    if (new Set(unitStackConfigs).size !== unitStackConfigs.length) {
-      return true;
-    }
-  };
-
   const checkForPendingEdits = () => {
     return Object.values(formState)
       .flat()
@@ -1192,8 +1173,6 @@ export const ConfigurationManagement = ({
     switch (msg) {
       case errorMessages.NOT_CHECKED_OUT:
         return canCheckOut && !isCheckedOutByUser;
-      case errorMessages.DUPLICATE_STACKPIPE_IDS:
-        return checkForDuplicateStackPipeIds();
       case errorMessages.EDITS_PENDING:
         return checkForPendingEdits();
       default:

--- a/src/components/ErrorSuppression/AddErrorSuppressionModal/AddErrorSuppressionModal.js
+++ b/src/components/ErrorSuppression/AddErrorSuppressionModal/AddErrorSuppressionModal.js
@@ -33,6 +33,7 @@ import { createErrorSuppression } from "../../../utils/api/errorSuppressionApi";
 import { Preloader } from "@us-epa-camd/easey-design-system";
 
 import { successResponses } from "../../../utils/api/apiUtils";
+import { formatErrorResponse } from '../../../utils/functions.js';
 
 export const AddErrorSupressionModal = ({
   showModal,
@@ -406,7 +407,7 @@ export const AddErrorSupressionModal = ({
       if (successResponses.includes(resp.status)) {
         close();
       } else {
-        const errorResp = Array.isArray(resp) ? resp : [resp];
+        const errorResp = formatErrorResponse(resp);
         setErrorMsgs(errorResp);
       }
     } catch (error) {

--- a/src/components/datatablesContainer/DataTableComments/DataTableComments.js
+++ b/src/components/datatablesContainer/DataTableComments/DataTableComments.js
@@ -28,6 +28,7 @@ import {
 import { ensure508 } from "../../../additional-functions/ensure-508";
 import { returnsFocusMpDatatableCreateBTN } from "../../../additional-functions/ensure-508";
 import PropTypes from 'prop-types';
+import { formatErrorResponse } from '../../../utils/functions';
 
 export const DataTableComments = ({
   locationSelectValue,
@@ -176,7 +177,7 @@ export const DataTableComments = ({
         setUpdateTable(true);
         setUpdateRelatedTables(true);
       } else {
-        const errorResp = Array.isArray(resp) ? resp : [resp];
+        const errorResp = formatErrorResponse(resp);
         setErrorMsgs(errorResp);
       }
     } catch (error) {
@@ -194,7 +195,7 @@ export const DataTableComments = ({
         setUpdateTable(true);
         setUpdateRelatedTables(true);
       } else {
-        const errorResp = Array.isArray(resp) ? resp : [resp];
+        const errorResp = formatErrorResponse(resp);
         setErrorMsgs(errorResp);
       }
     } catch (error) {

--- a/src/components/datatablesContainer/DataTableMats/DataTableMats.js
+++ b/src/components/datatablesContainer/DataTableMats/DataTableMats.js
@@ -36,6 +36,7 @@ import {
 } from "../../../additional-functions/prompt-to-save-unsaved-changes";
 import { ensure508 } from "../../../additional-functions/ensure-508";
 import { returnsFocusMpDatatableCreateBTN } from "../../../additional-functions/ensure-508";
+import { formatErrorResponse } from '../../../utils/functions.js';
 
 export const DataTableMats = ({
   mdmData,
@@ -214,7 +215,7 @@ export const DataTableMats = ({
         setUpdateTable(true);
         setUpdateRelatedTables(true);
       } else {
-        const errorResp = Array.isArray(resp) ? resp : [resp];
+        const errorResp = formatErrorResponse(resp);
         setErrorMsgs(errorResp);
       }
     } catch (error) {
@@ -237,7 +238,7 @@ export const DataTableMats = ({
         setUpdateTable(true);
         setUpdateRelatedTables(true);
       } else {
-        const errorResp = Array.isArray(resp) ? resp : [resp];
+        const errorResp = formatErrorResponse(resp);
         setErrorMsgs(errorResp);
       }
     } catch (error) {

--- a/src/components/datatablesContainer/DataTableMethod/DataTableMethod.js
+++ b/src/components/datatablesContainer/DataTableMethod/DataTableMethod.js
@@ -37,6 +37,7 @@ import {
 } from "../../../additional-functions/prompt-to-save-unsaved-changes";
 import { successResponses } from "../../../utils/api/apiUtils";
 import { returnsFocusMpDatatableCreateBTN } from "../../../additional-functions/ensure-508";
+import { formatErrorResponse } from '../../../utils/functions.js';
 
 
 export const DataTableMethod = ({
@@ -383,7 +384,7 @@ export const DataTableMethod = ({
         setUpdateTable(true);
         setUpdateRelatedTables(true);
       } else {
-        const errorResp = Array.isArray(resp) ? resp : [resp];
+        const errorResp = formatErrorResponse(resp);
         setErrorMsgs(errorResp);
       }
     } catch (error) {
@@ -409,7 +410,7 @@ export const DataTableMethod = ({
         setUpdateTable(true);
         setUpdateRelatedTables(true);
       } else {
-        const errorResp = Array.isArray(resp) ? resp : [resp];
+        const errorResp = formatErrorResponse(resp);
         setErrorMsgs(errorResp);
       }
     } catch (error) {

--- a/src/components/datatablesContainer/DataTableQualifications/DataTableQualifications.js
+++ b/src/components/datatablesContainer/DataTableQualifications/DataTableQualifications.js
@@ -44,6 +44,7 @@ import {
   unsavedDataMessage,
 } from "../../../additional-functions/prompt-to-save-unsaved-changes";
 import { returnsFocusMpDatatableCreateBTN } from "../../../additional-functions/ensure-508";
+import { formatErrorResponse } from '../../../utils/functions.js';
 import "./DataTableQualifications.scss";
 
 export const DataTableQualifications = ({
@@ -291,7 +292,7 @@ export const DataTableQualifications = ({
         setUpdateRelatedTables(true);
         setErrorMsgs([]);
       } else {
-        const errorResp = Array.isArray(resp) ? resp : [resp];
+        const errorResp = formatErrorResponse(resp);
         setErrorMsgs(errorResp);
       }
     } catch (error) {

--- a/src/components/datatablesContainer/DataTableSystems/DataTableSystems.js
+++ b/src/components/datatablesContainer/DataTableSystems/DataTableSystems.js
@@ -45,6 +45,7 @@ import {
   returnFocusToLast,
 } from "../../../additional-functions/manage-focus";
 import { successResponses } from "../../../utils/api/apiUtils";
+import { formatErrorResponse } from "../../../utils/functions";
 import "./DataTableSystems.scss"
 
 export const DataTableSystems = ({
@@ -395,7 +396,7 @@ export const DataTableSystems = ({
         setErrorMsgs([]);
         executeOnClose();
       } else {
-        const errorResp = Array.isArray(resp) ? resp : [resp];
+        const errorResp = formatErrorResponse(resp);
         setErrorMsgs(errorResp);
       }
     } catch (error) {
@@ -421,7 +422,7 @@ export const DataTableSystems = ({
         setErrorMsgs([]);
         executeOnClose();
       } else {
-        const errorResp = Array.isArray(resp) ? resp : [resp];
+        const errorResp = formatErrorResponse(resp);
         setErrorMsgs(errorResp);
       }
     } catch (error) {
@@ -464,7 +465,7 @@ export const DataTableSystems = ({
         setErrorMsgs([]);
         return true;
       } else {
-        const errorResp = Array.isArray(resp) ? resp : [resp];
+        const errorResp = formatErrorResponse(resp);
         setErrorMsgs(errorResp);
       }
     } catch (error) {
@@ -508,7 +509,7 @@ export const DataTableSystems = ({
         setErrorMsgs([]);
         return true;
       } else {
-        const errorResp = Array.isArray(resp) ? resp : [resp];
+        const errorResp = formatErrorResponse(resp);
         setErrorMsgs(errorResp);
       }
     } catch (error) {
@@ -556,7 +557,7 @@ export const DataTableSystems = ({
         setErrorMsgs([]);
         return true;
       } else {
-        const errorResp = Array.isArray(resp) ? resp : [resp];
+        const errorResp = formatErrorResponse(resp);
         setErrorMsgs(errorResp);
       }
     } catch (error) {
@@ -591,7 +592,7 @@ export const DataTableSystems = ({
         setUpdateRelatedTables(true);
         return true;
       } else {
-        const errorResp = Array.isArray(resp) ? resp : [resp];
+        const errorResp = formatErrorResponse(resp);
         setErrorMsgs(errorResp);
       }
     } catch (error) {
@@ -654,7 +655,7 @@ export const DataTableSystems = ({
         setErrorMsgs([]);
         return true;
       } else {
-        const errorResp = Array.isArray(resp) ? resp : [resp];
+        const errorResp = formatErrorResponse(resp);
         setErrorMsgs(errorResp);
       }
     } catch (error) {

--- a/src/components/qaDatatablesContainer/QAExpandableRowsRender/QAExpandableRowsRender.js
+++ b/src/components/qaDatatablesContainer/QAExpandableRowsRender/QAExpandableRowsRender.js
@@ -43,6 +43,7 @@ import {
   qaHgInjectionDataProps,
   qaUnitDefaultTestRunDataProps,
 } from '../../../additional-functions/qa-dataTable-props';
+import { formatErrorResponse } from '../../../utils/functions.js';
 
 const QAExpandableRowsRender = ({
   user,
@@ -851,7 +852,7 @@ const QAExpandableRowsRender = ({
         setUpdateTable(true);
         executeOnClose();
       } else {
-        const errorResp = Array.isArray(resp) ? resp : [resp];
+        const errorResp = formatErrorResponse(resp);
         setErrorMsgs(errorResp);
       }
     } catch (error) {
@@ -885,7 +886,7 @@ const QAExpandableRowsRender = ({
         setUpdateTable(true);
         executeOnClose();
       } else {
-        const errorResp = Array.isArray(resp) ? resp : [resp];
+        const errorResp = formatErrorResponse(resp);
         setErrorMsgs(errorResp);
       }
     } catch (error) {


### PR DESCRIPTION
## Ticket
[Check Gaps: MP Screen Only and Import Checks](https://github.com/US-EPA-CAMD/easey-ui/issues/6907)

## Changes
Remove frontend validation for duplicateStackPipeIds and duplicateUnitStackConfigs