### PR TITLE
fix(component-creation): conditionally check API response status

### DIFF
--- a/src/components/datatablesContainer/DataTableSystems/DataTableSystems.js
+++ b/src/components/datatablesContainer/DataTableSystems/DataTableSystems.js
@@ -649,7 +649,9 @@ export const DataTableSystems = ({
         )
         .catch((error) => log.log("createSystemsComponents failed", error));
 
-      if ((resp?.status >= 200 && resp?.status < 300) || (response?.status >= 200 && response?.status < 300)) {
+    const responseSuccess = response?.status >= 200 && response?.status < 300;
+    const respSuccess = addExistingComponentFlag ? true : (resp?.status >= 200 && resp?.status < 300);
+      if (responseSuccess && respSuccess) {
         setupdateComponentTable(true);
         setUpdateRelatedTables(true);
         setErrorMsgs([]);


### PR DESCRIPTION
## Ticket
[Check Gaps: MP Screen Only and Import Checks](https://github.com/US-EPA-CAMD/easey-ui/issues/6907)

## Change
- Conditionally validate 'resp' based on addExistingComponentFlag