### PR TITLE
Fix/6894 refresh qualifications table

### DIFF
--- a/src/components/ModalAddComponent/ModalAddComponent.js
+++ b/src/components/ModalAddComponent/ModalAddComponent.js
@@ -33,7 +33,6 @@ const ModalAddComponent = ({
       mpApi
         .getMonitoringSystemsComponents(locationId, systemId)
         .then((ress) => {
-          log.log("ress", ress);
           setSysComps(ress.data?.items);
         })
         .catch((error) =>

--- a/src/components/datatablesContainer/DataTableQualifications/DataTableQualifications.js
+++ b/src/components/datatablesContainer/DataTableQualifications/DataTableQualifications.js
@@ -59,6 +59,7 @@ export const DataTableQualifications = ({
   setRevertedState,
   selectedLocation,
   setUpdateRelatedTables,
+  updateRelatedTables,
   currentTabIndex,
   //
 
@@ -120,7 +121,8 @@ export const DataTableQualifications = ({
       updateTable ||
       qualificationData?.length <= 0 ||
       locationSelectValue ||
-      revertedState
+      revertedState ||
+      updateRelatedTables
     ) {
       setDataLoaded(false);
       mpApi
@@ -138,7 +140,7 @@ export const DataTableQualifications = ({
         .catch((error) => log.log("getQualifications failed", error));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [locationSelectValue, updateTable, revertedState]);
+  }, [locationSelectValue, updateTable, revertedState, updateRelatedTables]);
 
   // load dropdowns data (called once)
   useEffect(() => {

--- a/src/components/datatablesContainer/DataTableSystems/DataTableSystems.js
+++ b/src/components/datatablesContainer/DataTableSystems/DataTableSystems.js
@@ -631,19 +631,20 @@ export const DataTableSystems = ({
       setErrorMsgs(validationErrors);
       return false;
     }
+
     try {
       let resp;
       let response;
-        if (!addExistingComponentFlag) {
-          resp = await mpApi
+      if (!addExistingComponentFlag) {
+        resp = await mpApi
           .createComponents(
             userInput,
             selectedSystem.locationId,
             selectedSystem.id
           )
           .catch((error) => log.log("createComponents failed", error));
-        }
-        response = await mpApi
+      }
+      response = await mpApi
         .createSystemsComponents(
           userInput,
           selectedSystem.locationId,
@@ -651,16 +652,18 @@ export const DataTableSystems = ({
         )
         .catch((error) => log.log("createSystemsComponents failed", error));
 
-    const responseSuccess = response?.status >= 200 && response?.status < 300;
-    const respSuccess = addExistingComponentFlag ? true : (resp?.status >= 200 && resp?.status < 300);
+      const responseSuccess = response?.status >= 200 && response?.status < 300;
+      const respSuccess = addExistingComponentFlag ? true : (resp?.status >= 200 && resp?.status < 300);
+
       if (responseSuccess && respSuccess) {
         setupdateComponentTable(true);
         setUpdateRelatedTables(true);
         setErrorMsgs([]);
         return true;
       } else {
-        const errorResp = formatErrorResponse(resp);
-        setErrorMsgs(errorResp);
+        const errorResponse = formatErrorResponse(response);
+        const errorResp = resp ? formatErrorResponse(resp) : [];
+        setErrorMsgs(errorResponse.concat(errorResp));
       }
     } catch (error) {
       setErrorMsgs([JSON.stringify(error)]);


### PR DESCRIPTION
## Related Issues:

- https://github.com/US-EPA-CAMD/easey-ui/issues/6894

## Main Changes:

- Set the Monitor Qualifications table to refresh after importing a JSON file. This was done for other tables in the module but missed for Monitor Qualifications.
- Fixed an undefined access issue when formatting errors from the Monitor Systems modal.