### PR TITLE
Fix/6980 undefined access

### DIFF
--- a/src/components/ImportModal/import-functions.js
+++ b/src/components/ImportModal/import-functions.js
@@ -33,7 +33,7 @@ export const checkingCorrectSchema = (
           setDisablePortBtn
         );
       } // incorrect schema with section
-      if (!file.unitStackConfigurationData) {
+      if (!file.monitoringLocationData) {
         errorChecks(true);
         setSchemaErrors(["Only Monitoring Plan (MP) files may be imported"]);
       }


### PR DESCRIPTION
## Related Issues:

- https://github.com/US-EPA-CAMD/easey-ui/issues/6980

## Main Changes:

- Updated the front-end file import sanity check for MP files to check for the existence of the `monitoringLocationData` array (a required field) rather than the `unitStackConfigurationData` array (an optional field).