### PR TITLE
Fix/#7051 edit flow load reference records

### DIFF
--- a/src/components/qaDatatablesContainer/QAExpandableRowsRender/QAExpandableRowsRender.js
+++ b/src/components/qaDatatablesContainer/QAExpandableRowsRender/QAExpandableRowsRender.js
@@ -269,12 +269,8 @@ const QAExpandableRowsRender = ({
                   name: '-- Select a value --',
                 });
               } else {
-                dropdowns[dropdownArray[i]] = val.data?.items?.map(d => {
-                  return {
-                    code: d['vendorId'],
-                    name: d['vendorName'],
-                  };
-                });
+                const list = val.data?.items ?? val.data ?? [];
+                dropdowns[dropdownArray[i]] = mapResponseItems(list, 'vendorId', 'vendorName', {concat: true, sortBy: 'code'});
                 dropdowns[dropdownArray[i]].unshift({
                   code: '',
                   name: '-- Select a value --',
@@ -635,8 +631,27 @@ const QAExpandableRowsRender = ({
     }
   };
 
-  const mapResponseItems = (response, codeLabel, descriptionLabel) => {
-    return response.map((d) => ({ code: d[codeLabel], name: d[descriptionLabel] }));
+  const mapResponseItems = (response, codeLabel, descriptionLabel, { concat = false, sortBy, sortOrder = "asc", } = {}) => {
+    let mapped = response.map((d) => {
+      const code = d[codeLabel];
+      const name = d[descriptionLabel];
+
+      return {
+        code,
+        name: concat ? `${code} - ${name}` : name,
+      };
+    });
+    if (sortBy) {
+      mapped.sort((a, b) => {
+        const valA = a[sortBy]?.toString().toLowerCase();
+        const valB = b[sortBy]?.toString().toLowerCase();
+        if (valA < valB) return sortOrder === "asc" ? -1 : 1;
+        if (valA > valB) return sortOrder === "asc" ? 1 : -1;
+        return 0;
+      });
+    }
+
+    return mapped;
   };
 
   useEffect(() => {

--- a/src/components/qaDatatablesContainer/QAExpandableRowsRender/QAExpandableRowsRender.js
+++ b/src/components/qaDatatablesContainer/QAExpandableRowsRender/QAExpandableRowsRender.js
@@ -841,7 +841,6 @@ const QAExpandableRowsRender = ({
     }
 
     try {
-      console.log("userInputuserInputuserInputuserInput", userInput)
       const resp = await assertSelector.saveDataSwitch(
         userInput,
         dataTableName,

--- a/src/components/qaDatatablesContainer/QAExpandableRowsRender/QAExpandableRowsRender.js
+++ b/src/components/qaDatatablesContainer/QAExpandableRowsRender/QAExpandableRowsRender.js
@@ -590,9 +590,7 @@ const QAExpandableRowsRender = ({
                   break;
               }
               const list = curResp.data?.items ?? curResp.data ?? [];
-              dropdowns[dropdownArray[i]] = list.map(d => {
-                return { code: d[codeLabel], name: d[descriptionLabel] };
-              });
+              dropdowns[dropdownArray[i]] = mapResponseItems(list, codeLabel, descriptionLabel);
             });
             for (const options of Object.values(dropdowns)) {
               options.unshift({ code: '', name: '-- Select a value --' });
@@ -644,6 +642,11 @@ const QAExpandableRowsRender = ({
         break;
     }
   };
+
+  const mapResponseItems = (response, codeLabel, descriptionLabel) => {
+    return response.map((d) => ({ code: d[codeLabel], name: d[descriptionLabel] }));
+  };
+
   useEffect(() => {
     // Load MDM data (for dropdowns) only if we don't have them already
     if (!dropdownArrayIsEmpty && mdmData === null) {

--- a/src/components/qaDatatablesContainer/QAExpandableRowsRender/QAExpandableRowsRender.js
+++ b/src/components/qaDatatablesContainer/QAExpandableRowsRender/QAExpandableRowsRender.js
@@ -445,9 +445,8 @@ const QAExpandableRowsRender = ({
                 default:
                   break;
               }
-              dropdowns[dropdownArray[i]] = curResp.data?.items?.map(d => {
-                return { code: d[codeLabel], name: d[descriptionLabel] };
-              });
+              const list = curResp.data?.items ?? curResp.data ?? [];
+              dropdowns[dropdownArray[i]] = mapResponseItems(list, codeLabel, descriptionLabel);
             });
             for (const options of Object.values(dropdowns)) {
               options.unshift({ code: '', name: '-- Select a value --' });
@@ -472,9 +471,8 @@ const QAExpandableRowsRender = ({
                 default:
                   break;
               }
-              dropdowns[dropdownArray[i]] = curResp.data?.items?.map(d => {
-                return { code: d[codeLabel], name: d[descriptionLabel] };
-              });
+              const list = curResp.data?.items ?? curResp.data ?? [];
+              dropdowns[dropdownArray[i]] = mapResponseItems(list, codeLabel, descriptionLabel);
             });
             for (const options of Object.values(dropdowns)) {
               options.unshift({ code: '', name: '-- Select a value --' });
@@ -504,9 +502,8 @@ const QAExpandableRowsRender = ({
                 default:
                   break;
               }
-              dropdowns[dropdownArray[i]] = curResp.data?.items?.map(d => {
-                return { code: d[codeLabel], name: d[descriptionLabel] };
-              });
+              const list = curResp.data?.items ?? curResp.data ?? [];
+              dropdowns[dropdownArray[i]] = mapResponseItems(list, codeLabel, descriptionLabel);
               if (i === 1) {
                 dropdowns['oilVolumeUnitsOfMeasureCode'] = curResp.data?.items?.map(
                   d => {
@@ -542,16 +539,11 @@ const QAExpandableRowsRender = ({
                 default:
                   break;
               }
-              dropdowns[dropdownArray[i]] = curResp.data?.items?.map(d => {
-                return { code: d[codeLabel], name: d[descriptionLabel] };
-              });
+              const list = curResp.data?.items ?? curResp.data ?? [];
+              dropdowns[dropdownArray[i]] = mapResponseItems(list, codeLabel, descriptionLabel);
               if (i === 0) {
-                dropdowns['midLevelAccuracySpecCode'] = curResp.data?.items?.map(d => {
-                  return { code: d[codeLabel], name: d[descriptionLabel] };
-                });
-                dropdowns['highLevelAccuracySpecCode'] = curResp.data?.items?.map(d => {
-                  return { code: d[codeLabel], name: d[descriptionLabel] };
-                });
+                dropdowns['midLevelAccuracySpecCode'] = mapResponseItems(list, codeLabel, descriptionLabel);
+                dropdowns['highLevelAccuracySpecCode'] = mapResponseItems(list, codeLabel, descriptionLabel);
               }
             });
             for (const options of Object.values(dropdowns)) {

--- a/src/components/qaDatatablesContainer/QAExpandableRowsRender/QAExpandableRowsRender.js
+++ b/src/components/qaDatatablesContainer/QAExpandableRowsRender/QAExpandableRowsRender.js
@@ -589,7 +589,8 @@ const QAExpandableRowsRender = ({
                 default:
                   break;
               }
-              dropdowns[dropdownArray[i]] = curResp.data?.items?.map(d => {
+              const list = curResp.data?.items ?? curResp.data ?? [];
+              dropdowns[dropdownArray[i]] = list.map(d => {
                 return { code: d[codeLabel], name: d[descriptionLabel] };
               });
             });
@@ -840,6 +841,7 @@ const QAExpandableRowsRender = ({
     }
 
     try {
+      console.log("userInputuserInputuserInputuserInput", userInput)
       const resp = await assertSelector.saveDataSwitch(
         userInput,
         dataTableName,

--- a/src/utils/api/dataManagementApi.js
+++ b/src/utils/api/dataManagementApi.js
@@ -731,9 +731,10 @@ export const getRataTestNumber = async (locationId) => {
 
 	const allTestSummaries =
 		allPromises.length > 1
-			? [...testSummaries[0].data, ...testSummaries[1].data]
-			: testSummaries[0].data
-	const rataTestNumbers = allTestSummaries.map((testSummary) => {
+			? [...testSummaries[0].data.items, ...testSummaries[1].data.items]
+			: testSummaries[0].data.items
+	const list = allTestSummaries.items ?? allTestSummaries ?? [];
+	const rataTestNumbers = list.map((testSummary) => {
 		const testNumber = testSummary.testNumber
 		return {
 			rataTestNumberCode: testNumber,


### PR DESCRIPTION
## Ticket
[Can't Add/ Edit Flow to Load Reference Records](https://github.com/US-EPA-CAMD/easey-ui/issues/7051)
[Can't Add/ Edit RATA Traverse Records](https://github.com/US-EPA-CAMD/easey-ui/issues/7050)
[Protocol Gas Record - Vendor Identification Field Issue](https://github.com/US-EPA-CAMD/easey-ui/issues/7054)

## Changes

- Refactor data handling for test summaries and dropdowns