### PR TITLE
fix(date-picker): convert external input to YYYY-MM-DD format

### DIFF
--- a/src/additional-functions/extract-user-input.js
+++ b/src/additional-functions/extract-user-input.js
@@ -12,7 +12,7 @@ export const extractUserInput = (payload, inputSelector, radios) => {
   // *** construct payload
   const payloadInputs = document.querySelectorAll(`${inputSelector},.modalLockedInput`);
   const datepickerPayloads = document.querySelectorAll(
-    ".usa-date-picker__internal-input"
+    ".usa-date-picker__external-input"
   );
   let radioPayload = null;
   const payloadArray = [];
@@ -39,7 +39,13 @@ export const extractUserInput = (payload, inputSelector, radios) => {
   datepickerPayloads.forEach((input) => {
     const item = { name: "", value: "" };
     item.name = input.attributes["epadataname"].value;
-    item.value = input.value;
+    // Convert MM/DD/YYYY -> YYYY-MM-DD
+    if (input.value) {
+      const [month, day, year] = input.value.split("/");
+      item.value = `${year}-${month.padStart(2, "0")}-${day.padStart(2, "0")}`;
+    } else {
+      item.value = null;
+    }
     payloadArray.push(item);
   });
 

--- a/src/additional-functions/qa-dataTable-props.js
+++ b/src/additional-functions/qa-dataTable-props.js
@@ -31,6 +31,7 @@ export const qaProtocalGasProps = selectedRow => {
     },
     controlDatePickerInputs: {},
     extraControls: {},
+    futureDateFields: ['expirationDate'],
   };
 };
 

--- a/src/components/qaDatatablesContainer/QAExpandableRowsRender/QAExpandableRowsRender.js
+++ b/src/components/qaDatatablesContainer/QAExpandableRowsRender/QAExpandableRowsRender.js
@@ -214,8 +214,25 @@ const QAExpandableRowsRender = ({
       expandable: expand,
       user: user,
       isCheckedOut: isCheckedOut,
-      parentId: parentId
+      parentId: parentId,
+      futureDateFields: objProps['futureDateFields'],
     };
+  };
+
+  const shouldAllowFutureDates = () => {
+    const objProps = nextExpandableRow(dataTableName);
+    
+    const futureDateFields = objProps?.futureDateFields || [];
+    if (futureDateFields.length === 0) return false;
+    if (selectedModalData) {
+      for (const field of selectedModalData) {
+        if (futureDateFields.includes(field[0])) { 
+          return true;
+        }
+      }
+    }
+
+    return false;
   };
 
   const populateStaticDropdowns = (tableName, dropdowns) => {
@@ -1028,6 +1045,7 @@ const QAExpandableRowsRender = ({
                   title={`${dataTableName}`}
                   viewOnly={!user || (user && !isCheckedOut)}
                   create={createNewData}
+                  allowFutureDates={shouldAllowFutureDates()}
                 />
               </div>
             ) : (


### PR DESCRIPTION
## Ticket
[Protocol Gas Record - Can't Save Future Expiration Date](https://github.com/US-EPA-CAMD/easey-ui/issues/7052)

## Changes
- Switched datepicker querySelector to use `usa-date-picker__external-input`
- Added conversion from MM/DD/YYYY (external input) to YYYY-MM-DD for payload consistency
