### PR TITLE
Fix/7043 emissions file not importing

### DIFF
--- a/src/components/HeaderInfo/HeaderInfo.js
+++ b/src/components/HeaderInfo/HeaderInfo.js
@@ -874,6 +874,7 @@ export const HeaderInfo = ({
       })
       .catch((err) => {
         log.log(err);
+        setImportedFileErrorMsgs(["There was an error importing the file."]);
       })
       .finally(() => {
         setIsLoading(false);
@@ -920,6 +921,7 @@ export const HeaderInfo = ({
       })
       .catch((err) => {
         log.log(err);
+        setImportedFileErrorMsgs(["There was an error importing the file."]);
       })
       .finally(() => {
         setIsLoading(false);

--- a/src/components/QACertEventHeaderInfo/QACertEventHeaderInfo.js
+++ b/src/components/QACertEventHeaderInfo/QACertEventHeaderInfo.js
@@ -209,6 +209,7 @@ export const QACertEventHeaderInfo = ({
       })
       .catch((err) => {
         log.log(err);
+        setImportedFileErrorMsgs(["There was an error importing the file."]);
       })
       .finally(() => {
         setIsLoading(false);

--- a/src/components/QACertTestSummaryHeaderInfo/QACertTestSummaryHeaderInfo.js
+++ b/src/components/QACertTestSummaryHeaderInfo/QACertTestSummaryHeaderInfo.js
@@ -246,6 +246,7 @@ export const QACertTestSummaryHeaderInfo = ({
       })
       .catch((err) => {
         log.log(err);
+        setImportedFileErrorMsgs(["There was an error importing the file."]);
       })
       .finally(() => {
         setIsLoading(false);


### PR DESCRIPTION
## Related Issues:

- https://github.com/US-EPA-CAMD/easey-ui/issues/7043

## Main Changes:

- If an error occurs in any of the import response handlers, show an error message instead of success. This will handle the specific case of a type error when reading a 504 Gateway Timeout response, but also other unanticipated errors.