### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,6 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 50
+    ignore:
+      - dependency-name: "eslint"
+        versions: [">=10.0.0"]


### PR DESCRIPTION
ignore eslint 10 (breaking changes and v9 is still being maintained)

